### PR TITLE
docs: add package-level godoc comments to 15 packages

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,3 +1,4 @@
+// Package cmd implements all td CLI commands using cobra.
 package cmd
 
 import (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,5 @@
+// Package config handles loading and saving td configuration from
+// .todos/config.json.
 package config
 
 import (

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,3 +1,5 @@
+// Package db provides the SQLite persistence layer for td, handling issue
+// storage, migrations, multi-process locking, and query execution.
 package db
 
 import (

--- a/internal/dependency/dependency.go
+++ b/internal/dependency/dependency.go
@@ -1,3 +1,5 @@
+// Package dependency provides cycle-safe dependency graph operations between
+// issues.
 package dependency
 
 import (

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1,3 +1,5 @@
+// Package git provides utilities for reading git repository state (branch,
+// commit, dirty status).
 package git
 
 import (

--- a/internal/input/input.go
+++ b/internal/input/input.go
@@ -1,3 +1,5 @@
+// Package input provides helpers for reading flag values from stdin and files
+// (@file syntax).
 package input
 
 import (

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,3 +1,5 @@
+// Package models defines the core domain types (Issue, Log, Handoff,
+// WorkSession, Board, etc.) and their validation helpers.
 package models
 
 import (

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -1,3 +1,5 @@
+// Package output provides styled terminal output helpers (success, error,
+// warning, issue formatting) using lipgloss.
 package output
 
 import (

--- a/internal/query/parser.go
+++ b/internal/query/parser.go
@@ -1,3 +1,5 @@
+// Package query implements the TDQ (td query) language parser, lexer, AST,
+// and evaluator for filtering issues.
 package query
 
 import (

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,3 +1,5 @@
+// Package session manages terminal and agent work sessions scoped by git
+// branch and agent identity.
 package session
 
 import (

--- a/internal/suggest/suggest.go
+++ b/internal/suggest/suggest.go
@@ -1,3 +1,5 @@
+// Package suggest provides fuzzy matching for CLI flag and command suggestions
+// using Levenshtein distance.
 package suggest
 
 import (

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,5 @@
+// Package version provides update checking against GitHub releases and
+// semantic version comparison.
 package version
 
 import (

--- a/internal/workdir/workdir.go
+++ b/internal/workdir/workdir.go
@@ -1,3 +1,5 @@
+// Package workdir resolves the td database root directory, supporting git
+// worktree redirection via .td-root files.
 package workdir
 
 import (

--- a/pkg/monitor/keymap/config.go
+++ b/pkg/monitor/keymap/config.go
@@ -1,3 +1,5 @@
+// Package keymap provides user-configurable key bindings for the TUI monitor,
+// loaded from .todos/keymap.json.
 package keymap
 
 import (

--- a/pkg/monitor/mouse/mouse.go
+++ b/pkg/monitor/mouse/mouse.go
@@ -1,3 +1,5 @@
+// Package mouse provides rectangular hit region tracking and double-click
+// detection for TUI mouse support.
 package mouse
 
 import (


### PR DESCRIPTION
## Summary
- Add standard `Package xyz ...` doc comments to all 15 Go packages that were missing them
- Each comment follows Go convention and concisely describes the package's purpose
- Packages already documented (workflow, agent, monitor, monitor/modal) are left unchanged

## Test plan
- [x] `go build` succeeds with no errors
- [x] `go test ./...` passes all tests (19 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)