### PR TITLE
feat: autofill dropdowns, inline status editing, and dynamic modal height

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yuin/goldmark v1.7.8 // indirect
 	github.com/yuin/goldmark-emoji v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
+github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/pkg/monitor/commands.go
+++ b/pkg/monitor/commands.go
@@ -95,7 +95,9 @@ func (m Model) handleFormUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch {
 		case keyMsg.Type == tea.KeyCtrlS:
 			return m.executeCommand(keymap.CmdFormSubmit)
-		case keyMsg.Type == tea.KeyEsc:
+		case keyMsg.Type == tea.KeyEsc && (m.FormState == nil || m.FormState.Autofill == nil || !m.FormState.Autofill.Active):
+			// Only cancel form if autofill dropdown is not active; Esc with dropdown
+			// active is handled below to dismiss just the dropdown.
 			return m.executeCommand(keymap.CmdFormCancel)
 		case keyMsg.Type == tea.KeyCtrlX:
 			return m.executeCommand(keymap.CmdFormToggleExtend)
@@ -103,8 +105,40 @@ func (m Model) handleFormUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.executeCommand(keymap.CmdFormOpenEditor)
 		}
 
+		// Autofill dropdown key interception: consume Up/Down/Enter/Esc
+		// before they reach huh or the button navigation logic.
+		// Only intercept when form fields are focused (not buttons).
+		if m.FormState != nil && m.FormState.Autofill != nil && m.FormState.Autofill.Active &&
+			len(m.FormState.Autofill.Filtered) > 0 && m.FormState.ButtonFocus == formButtonFocusForm {
+			switch keyMsg.Type {
+			case tea.KeyUp:
+				if m.FormState.Autofill.Idx > 0 {
+					m.FormState.Autofill.Idx--
+				}
+				return m, nil
+			case tea.KeyDown:
+				if m.FormState.Autofill.Idx < len(m.FormState.Autofill.Filtered)-1 {
+					m.FormState.Autofill.Idx++
+				}
+				return m, nil
+			case tea.KeyEnter:
+				return m.selectAutofillItem()
+			}
+		}
+		// Esc closes the autofill dropdown without closing the form
+		if m.FormState != nil && m.FormState.Autofill != nil && m.FormState.Autofill.Active {
+			if keyMsg.Type == tea.KeyEsc {
+				m.FormState.Autofill = nil
+				return m, nil
+			}
+		}
+
 		if m.FormState != nil {
 			moveToButtons := func(focus int) (tea.Model, tea.Cmd) {
+				// Clear autofill dropdown when leaving form fields for buttons
+				if focus != formButtonFocusForm {
+					m.FormState.Autofill = nil
+				}
 				// When moving away from form fields, blur the focused field
 				if focus != formButtonFocusForm && m.FormState.ButtonFocus == formButtonFocusForm {
 					if field := m.FormState.Form.GetFocusedField(); field != nil {
@@ -171,6 +205,22 @@ func (m Model) handleFormUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleEditorFinished(editorMsg)
 	}
 
+	// Handle autofill data loaded
+	if afMsg, ok := msg.(AutofillResultMsg); ok {
+		if m.FormState != nil {
+			m.FormState.AutofillAll = afMsg.Items
+			var epics []AutofillItem
+			for _, item := range afMsg.Items {
+				if item.Type == models.TypeEpic {
+					epics = append(epics, item)
+				}
+			}
+			m.FormState.AutofillEpics = epics
+			m.syncAutofillState()
+		}
+		return m, nil
+	}
+
 	// Handle window resize
 	if sizeMsg, ok := msg.(tea.WindowSizeMsg); ok {
 		m.Width = sizeMsg.Width
@@ -187,6 +237,9 @@ func (m Model) handleFormUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if f, ok := form.(*huh.Form); ok {
 		m.FormState.Form = f
 	}
+
+	// Sync autofill state after huh processes the message (detects field focus changes)
+	m.syncAutofillState()
 
 	// Check if form completed (user pressed enter on last field)
 	if m.FormState.Form.State == huh.StateCompleted {
@@ -1236,6 +1289,10 @@ func (m Model) executeCommand(cmd keymap.Command) (tea.Model, tea.Cmd) {
 	case keymap.CmdFormToggleExtend:
 		if m.FormState != nil {
 			m.FormState.ToggleExtended()
+			// Load autofill data when extended fields become visible (if not already loaded)
+			if m.FormState.ShowExtended && len(m.FormState.AutofillAll) == 0 {
+				return m, loadAutofillData(m.DB)
+			}
 		}
 		return m, nil
 

--- a/pkg/monitor/form_autofill.go
+++ b/pkg/monitor/form_autofill.go
@@ -1,0 +1,341 @@
+package monitor
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/marcus/td/internal/db"
+	"github.com/marcus/td/internal/models"
+	"github.com/sahilm/fuzzy"
+)
+
+// AutofillState holds state for an autocomplete dropdown attached to a form field.
+type AutofillState struct {
+	Active   bool           // Whether the dropdown is showing
+	FieldKey string         // Which form field this is for ("parent" or "dependencies")
+	Filtered []AutofillItem // Filtered by current query
+	Idx      int            // Selected index in dropdown
+	Query    string         // Current search text (tracked separately from huh field value)
+}
+
+// AutofillItem represents a single autocomplete suggestion.
+type AutofillItem struct {
+	ID    string
+	Title string
+	Type  models.Type
+}
+
+// AutofillResultMsg carries loaded issues for the autocomplete dropdown.
+type AutofillResultMsg struct {
+	Items []AutofillItem
+}
+
+// loadAutofillData fetches all non-closed issues from the database for autocomplete.
+func loadAutofillData(database *db.DB) tea.Cmd {
+	return func() tea.Msg {
+		issues, err := database.ListIssues(db.ListIssuesOptions{
+			Status: []models.Status{
+				models.StatusOpen,
+				models.StatusInProgress,
+				models.StatusBlocked,
+				models.StatusInReview,
+			},
+			Limit: 500,
+		})
+		if err != nil {
+			return AutofillResultMsg{Items: nil}
+		}
+
+		items := make([]AutofillItem, len(issues))
+		for i, issue := range issues {
+			items[i] = AutofillItem{
+				ID:    issue.ID,
+				Title: issue.Title,
+				Type:  issue.Type,
+			}
+		}
+		return AutofillResultMsg{Items: items}
+	}
+}
+
+// autofillSearchSource adapts []AutofillItem for the fuzzy library.
+// Each item produces a searchable string of "ID Title" so fuzzy matching
+// works across both fields simultaneously.
+type autofillSearchSource []AutofillItem
+
+func (s autofillSearchSource) String(i int) string {
+	return s[i].ID + " " + s[i].Title
+}
+
+func (s autofillSearchSource) Len() int {
+	return len(s)
+}
+
+// filterAutofillItems uses fzf-style fuzzy matching on ID and Title,
+// returning results ranked by match quality (best first).
+func filterAutofillItems(query string, items []AutofillItem) []AutofillItem {
+	if query == "" {
+		return items
+	}
+
+	matches := fuzzy.FindFrom(query, autofillSearchSource(items))
+
+	// Sort by score descending (best match first)
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].Score > matches[j].Score
+	})
+
+	result := make([]AutofillItem, len(matches))
+	for i, m := range matches {
+		result[i] = items[m.Index]
+	}
+	return result
+}
+
+// currentDepToken extracts the text after the last comma for multi-select dependency input.
+// For "td-xxx, td-yyy, partial" it returns "partial".
+func currentDepToken(deps string) string {
+	parts := strings.Split(deps, ",")
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(parts[len(parts)-1])
+}
+
+// excludeIDs removes items whose IDs appear in the excluded set.
+func excludeIDs(items []AutofillItem, excluded []string) []AutofillItem {
+	if len(excluded) == 0 {
+		return items
+	}
+
+	set := make(map[string]bool, len(excluded))
+	for _, id := range excluded {
+		set[strings.TrimSpace(id)] = true
+	}
+
+	var result []AutofillItem
+	for _, item := range items {
+		if !set[item.ID] {
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+// isExactAutofillID returns true if query exactly matches an item's ID.
+// Used to suppress re-activation of the dropdown after selecting an item.
+func isExactAutofillID(query string, items []AutofillItem) bool {
+	if query == "" {
+		return false
+	}
+	for _, item := range items {
+		if item.ID == query {
+			return true
+		}
+	}
+	return false
+}
+
+// syncAutofillState detects which form field is focused and activates/deactivates
+// the autofill dropdown accordingly. Called after every huh form update.
+func (m *Model) syncAutofillState() {
+	if m.FormState == nil || !m.FormState.ShowExtended {
+		if m.FormState != nil {
+			m.FormState.Autofill = nil
+		}
+		return
+	}
+
+	focusedKey := m.FormState.focusedFieldKey()
+
+	switch focusedKey {
+	case formKeyParent:
+		query := m.FormState.Parent
+		// Don't show dropdown if value is an exact item ID (user just selected)
+		if isExactAutofillID(query, m.FormState.AutofillEpics) {
+			m.FormState.Autofill = nil
+			return
+		}
+		if m.FormState.Autofill == nil || m.FormState.Autofill.FieldKey != formKeyParent {
+			m.FormState.Autofill = &AutofillState{
+				Active:   true,
+				FieldKey: formKeyParent,
+			}
+		}
+		if query != m.FormState.Autofill.Query {
+			m.FormState.Autofill.Query = query
+			m.FormState.Autofill.Filtered = filterAutofillItems(query, m.FormState.AutofillEpics)
+			m.FormState.Autofill.Idx = 0
+		}
+
+	case formKeyDependencies:
+		query := currentDepToken(m.FormState.Dependencies)
+		// Don't show dropdown if current token is an exact item ID (user just selected)
+		if isExactAutofillID(query, m.FormState.AutofillAll) {
+			m.FormState.Autofill = nil
+			return
+		}
+		// Don't re-activate with empty query after selection cleared the state
+		if m.FormState.Autofill == nil && query == "" {
+			return
+		}
+		if m.FormState.Autofill == nil || m.FormState.Autofill.FieldKey != formKeyDependencies {
+			m.FormState.Autofill = &AutofillState{
+				Active:   true,
+				FieldKey: formKeyDependencies,
+			}
+		}
+		if query != m.FormState.Autofill.Query {
+			m.FormState.Autofill.Query = query
+			existing := parseLabels(m.FormState.Dependencies)
+			filtered := filterAutofillItems(query, m.FormState.AutofillAll)
+			filtered = excludeIDs(filtered, existing)
+			m.FormState.Autofill.Filtered = filtered
+			m.FormState.Autofill.Idx = 0
+		}
+
+	default:
+		m.FormState.Autofill = nil
+	}
+}
+
+// selectAutofillItem handles Enter in the autofill dropdown: populates the field
+// value, rebuilds the huh form, and restores focus to the target field.
+func (m Model) selectAutofillItem() (tea.Model, tea.Cmd) {
+	af := m.FormState.Autofill
+	if af == nil || len(af.Filtered) == 0 || af.Idx < 0 || af.Idx >= len(af.Filtered) {
+		return m, nil
+	}
+	selected := af.Filtered[af.Idx]
+
+	if af.FieldKey == formKeyParent {
+		m.FormState.Parent = selected.ID
+		m.FormState.Autofill = nil
+		m.FormState.buildForm()
+		// Init form synchronously (sets up fields), discard its cmd to avoid
+		// tea.WindowSize() race that snaps the form back to group 0.
+		_ = m.FormState.Form.Init()
+		// Navigate to details group; only this cmd runs async (target field cursor).
+		return m, m.FormState.Form.NextGroup()
+	}
+
+	if af.FieldKey == formKeyDependencies {
+		// Replace only the current token (text after last comma) with the selected ID
+		parts := strings.Split(m.FormState.Dependencies, ",")
+		if len(parts) > 0 {
+			parts[len(parts)-1] = " " + selected.ID
+		} else {
+			parts = []string{selected.ID}
+		}
+		m.FormState.Dependencies = strings.TrimSpace(strings.Join(parts, ",")) + ", "
+		// Close dropdown after selection (syncAutofillState won't re-activate
+		// because currentDepToken returns "" which triggers the nil guard)
+		m.FormState.Autofill = nil
+		m.FormState.buildForm()
+		// Init form synchronously, discard cmd to avoid tea.WindowSize() race.
+		_ = m.FormState.Form.Init()
+		_ = m.FormState.Form.NextGroup() // → detailsGroup (discard cmd)
+		_ = m.FormState.Form.NextGroup() // → workflowGroup, Minor (discard cmd)
+		// Navigate to Dependencies; only this cmd runs async (target field cursor).
+		return m, m.FormState.Form.NextField()
+	}
+
+	return m, nil
+}
+
+// insertDropdownAfterField injects dropdownView into formView by scanning
+// for the line containing nextFieldTitle and inserting the dropdown before it.
+// Uses ansi.Strip for reliable matching in ANSI-styled output.
+func insertDropdownAfterField(formView, dropdownView, nextFieldTitle string) string {
+	lines := strings.Split(formView, "\n")
+	var result []string
+	inserted := false
+	for _, line := range lines {
+		if !inserted && strings.Contains(ansi.Strip(line), nextFieldTitle) {
+			result = append(result, dropdownView)
+			inserted = true
+		}
+		result = append(result, line)
+	}
+	if !inserted {
+		// Fallback: append at end
+		result = append(result, dropdownView)
+	}
+	return strings.Join(result, "\n")
+}
+
+// renderFormAutofillDropdown renders the autocomplete dropdown for the active field.
+func (m Model) renderFormAutofillDropdown() string {
+	if m.FormState == nil || m.FormState.Autofill == nil || !m.FormState.Autofill.Active {
+		return ""
+	}
+	af := m.FormState.Autofill
+
+	if len(af.Filtered) == 0 {
+		if af.Query != "" {
+			return subtleStyle.Render("  No matching issues")
+		}
+		if af.FieldKey == formKeyParent && len(m.FormState.AutofillEpics) == 0 {
+			return subtleStyle.Render("  No epics found")
+		}
+		return ""
+	}
+
+	maxDropdown := 5
+	dropdownCount := len(af.Filtered)
+	if dropdownCount > maxDropdown {
+		dropdownCount = maxDropdown
+	}
+
+	formWidth := m.FormState.Width
+	if formWidth <= 0 {
+		formWidth = 60
+	}
+
+	var lines []string
+
+	// Header hint
+	fieldLabel := "epics"
+	if af.FieldKey == formKeyDependencies {
+		fieldLabel = "issues"
+	}
+	lines = append(lines, subtleStyle.Render(fmt.Sprintf("  Matching %s:", fieldLabel)))
+
+	for i := 0; i < dropdownCount; i++ {
+		item := af.Filtered[i]
+		prefix := "  "
+		if i == af.Idx {
+			prefix = "> "
+		}
+
+		title := item.Title
+		maxTitle := formWidth - len(item.ID) - 10
+		if maxTitle < 10 {
+			maxTitle = 10
+		}
+		if len(title) > maxTitle {
+			title = title[:maxTitle-3] + "..."
+		}
+
+		line := fmt.Sprintf("%s%s  %s", prefix, item.ID, title)
+		if i == af.Idx {
+			line = lipgloss.NewStyle().Foreground(primaryColor).Render(line)
+		} else {
+			line = subtleStyle.Render(line)
+		}
+		lines = append(lines, line)
+	}
+
+	if len(af.Filtered) > maxDropdown {
+		lines = append(lines, subtleStyle.Render(
+			fmt.Sprintf("  ... and %d more", len(af.Filtered)-maxDropdown)))
+	}
+
+	lines = append(lines, subtleStyle.Render("  ↑/↓ navigate  Enter select"))
+
+	return strings.Join(lines, "\n")
+}

--- a/pkg/monitor/form_autofill_test.go
+++ b/pkg/monitor/form_autofill_test.go
@@ -1,0 +1,244 @@
+package monitor
+
+import (
+	"testing"
+
+	"github.com/marcus/td/internal/models"
+)
+
+func TestFilterAutofillItems_EmptyQuery(t *testing.T) {
+	items := []AutofillItem{
+		{ID: "td-aaa", Title: "First item", Type: models.TypeTask},
+		{ID: "td-bbb", Title: "Second item", Type: models.TypeEpic},
+	}
+	result := filterAutofillItems("", items)
+	if len(result) != 2 {
+		t.Errorf("expected 2 items, got %d", len(result))
+	}
+}
+
+func TestFilterAutofillItems_ByID(t *testing.T) {
+	items := []AutofillItem{
+		{ID: "td-aaa111", Title: "First item", Type: models.TypeTask},
+		{ID: "td-bbb222", Title: "Second item", Type: models.TypeEpic},
+		{ID: "td-ccc333", Title: "Third item", Type: models.TypeTask},
+	}
+	result := filterAutofillItems("bbb", items)
+	if len(result) != 1 {
+		t.Errorf("expected 1 item, got %d", len(result))
+	}
+	if result[0].ID != "td-bbb222" {
+		t.Errorf("expected td-bbb222, got %s", result[0].ID)
+	}
+}
+
+func TestFilterAutofillItems_ByTitle(t *testing.T) {
+	items := []AutofillItem{
+		{ID: "td-aaa", Title: "Add authentication", Type: models.TypeTask},
+		{ID: "td-bbb", Title: "Fix login bug", Type: models.TypeBug},
+		{ID: "td-ccc", Title: "Auth refactor", Type: models.TypeFeature},
+	}
+	result := filterAutofillItems("auth", items)
+	if len(result) != 2 {
+		t.Errorf("expected 2 items, got %d", len(result))
+	}
+}
+
+func TestFilterAutofillItems_CaseInsensitive(t *testing.T) {
+	items := []AutofillItem{
+		{ID: "td-aaa", Title: "IMPORTANT Task", Type: models.TypeTask},
+	}
+	result := filterAutofillItems("important", items)
+	if len(result) != 1 {
+		t.Errorf("expected 1 item, got %d", len(result))
+	}
+}
+
+func TestFilterAutofillItems_NoMatch(t *testing.T) {
+	items := []AutofillItem{
+		{ID: "td-aaa", Title: "First item", Type: models.TypeTask},
+		{ID: "td-bbb", Title: "Second item", Type: models.TypeEpic},
+	}
+	result := filterAutofillItems("nonexistent", items)
+	if len(result) != 0 {
+		t.Errorf("expected 0 items, got %d", len(result))
+	}
+}
+
+func TestFilterAutofillItems_TDPrefix(t *testing.T) {
+	items := []AutofillItem{
+		{ID: "td-abc123", Title: "Task one", Type: models.TypeTask},
+		{ID: "td-def456", Title: "Task two", Type: models.TypeTask},
+	}
+	result := filterAutofillItems("td-abc", items)
+	if len(result) != 1 {
+		t.Errorf("expected 1 item, got %d", len(result))
+	}
+	if result[0].ID != "td-abc123" {
+		t.Errorf("expected td-abc123, got %s", result[0].ID)
+	}
+}
+
+func TestFilterAutofillItems_FuzzyMatch(t *testing.T) {
+	items := []AutofillItem{
+		{ID: "td-aaa", Title: "Add authentication module", Type: models.TypeTask},
+		{ID: "td-bbb", Title: "Fix login bug", Type: models.TypeBug},
+		{ID: "td-ccc", Title: "Auth token handler", Type: models.TypeFeature},
+	}
+	// "athn" should fuzzy-match items containing a-t-h-n in sequence
+	result := filterAutofillItems("athn", items)
+	if len(result) < 2 {
+		t.Fatalf("expected at least 2 fuzzy matches for 'athn', got %d", len(result))
+	}
+	// "Auth token handler" should rank highest: "a-t-h" are consecutive in "Auth"
+	if result[0].ID != "td-ccc" {
+		t.Errorf("expected td-ccc as best match, got %s", result[0].ID)
+	}
+	// "Fix login bug" should not match (no a-t-h-n sequence)
+	for _, item := range result {
+		if item.ID == "td-bbb" {
+			t.Error("expected td-bbb to not match 'athn'")
+		}
+	}
+}
+
+func TestFilterAutofillItems_FuzzyRanking(t *testing.T) {
+	items := []AutofillItem{
+		{ID: "td-aaa", Title: "Something else entirely", Type: models.TypeTask},
+		{ID: "td-bbb", Title: "Fix database migration", Type: models.TypeBug},
+		{ID: "td-abc123", Title: "Task runner", Type: models.TypeTask},
+	}
+	// "abc" should rank td-abc123 highest (exact ID substring match)
+	result := filterAutofillItems("abc", items)
+	if len(result) == 0 {
+		t.Fatal("expected at least 1 match for 'abc'")
+	}
+	if result[0].ID != "td-abc123" {
+		t.Errorf("expected td-abc123 as best match, got %s", result[0].ID)
+	}
+}
+
+func TestCurrentDepToken_SingleValue(t *testing.T) {
+	result := currentDepToken("td-aaa")
+	if result != "td-aaa" {
+		t.Errorf("expected 'td-aaa', got '%s'", result)
+	}
+}
+
+func TestCurrentDepToken_MultipleValues(t *testing.T) {
+	result := currentDepToken("td-aaa, td-bbb, partial")
+	if result != "partial" {
+		t.Errorf("expected 'partial', got '%s'", result)
+	}
+}
+
+func TestCurrentDepToken_TrailingComma(t *testing.T) {
+	result := currentDepToken("td-aaa, td-bbb, ")
+	if result != "" {
+		t.Errorf("expected empty string, got '%s'", result)
+	}
+}
+
+func TestCurrentDepToken_Empty(t *testing.T) {
+	result := currentDepToken("")
+	if result != "" {
+		t.Errorf("expected empty string, got '%s'", result)
+	}
+}
+
+func TestCurrentDepToken_WithSpaces(t *testing.T) {
+	result := currentDepToken("td-aaa,  td-bbb ,  td-c")
+	if result != "td-c" {
+		t.Errorf("expected 'td-c', got '%s'", result)
+	}
+}
+
+func TestExcludeIDs_RemovesExisting(t *testing.T) {
+	items := []AutofillItem{
+		{ID: "td-aaa", Title: "First"},
+		{ID: "td-bbb", Title: "Second"},
+		{ID: "td-ccc", Title: "Third"},
+	}
+	result := excludeIDs(items, []string{"td-bbb"})
+	if len(result) != 2 {
+		t.Errorf("expected 2 items, got %d", len(result))
+	}
+	for _, item := range result {
+		if item.ID == "td-bbb" {
+			t.Error("expected td-bbb to be excluded")
+		}
+	}
+}
+
+func TestExcludeIDs_EmptyExcluded(t *testing.T) {
+	items := []AutofillItem{
+		{ID: "td-aaa", Title: "First"},
+		{ID: "td-bbb", Title: "Second"},
+	}
+	result := excludeIDs(items, nil)
+	if len(result) != 2 {
+		t.Errorf("expected 2 items, got %d", len(result))
+	}
+}
+
+func TestExcludeIDs_AllExcluded(t *testing.T) {
+	items := []AutofillItem{
+		{ID: "td-aaa", Title: "First"},
+		{ID: "td-bbb", Title: "Second"},
+	}
+	result := excludeIDs(items, []string{"td-aaa", "td-bbb"})
+	if len(result) != 0 {
+		t.Errorf("expected 0 items, got %d", len(result))
+	}
+}
+
+func TestExcludeIDs_TrimSpaces(t *testing.T) {
+	items := []AutofillItem{
+		{ID: "td-aaa", Title: "First"},
+		{ID: "td-bbb", Title: "Second"},
+	}
+	result := excludeIDs(items, []string{" td-aaa "})
+	if len(result) != 1 {
+		t.Errorf("expected 1 item, got %d", len(result))
+	}
+	if result[0].ID != "td-bbb" {
+		t.Errorf("expected td-bbb, got %s", result[0].ID)
+	}
+}
+
+func TestIsExactAutofillID_Match(t *testing.T) {
+	items := []AutofillItem{
+		{ID: "td-aaa", Title: "First"},
+		{ID: "td-bbb", Title: "Second"},
+	}
+	if !isExactAutofillID("td-aaa", items) {
+		t.Error("expected true for exact ID match")
+	}
+}
+
+func TestIsExactAutofillID_NoMatch(t *testing.T) {
+	items := []AutofillItem{
+		{ID: "td-aaa", Title: "First"},
+	}
+	if isExactAutofillID("td-bbb", items) {
+		t.Error("expected false for non-matching ID")
+	}
+}
+
+func TestIsExactAutofillID_Empty(t *testing.T) {
+	items := []AutofillItem{
+		{ID: "td-aaa", Title: "First"},
+	}
+	if isExactAutofillID("", items) {
+		t.Error("expected false for empty query")
+	}
+}
+
+func TestIsExactAutofillID_Partial(t *testing.T) {
+	items := []AutofillItem{
+		{ID: "td-aaa123", Title: "First"},
+	}
+	if isExactAutofillID("td-aaa", items) {
+		t.Error("expected false for partial ID match")
+	}
+}

--- a/pkg/monitor/form_operations.go
+++ b/pkg/monitor/form_operations.go
@@ -1,12 +1,15 @@
 package monitor
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/marcus/td/internal/models"
+	"github.com/marcus/td/internal/workflow"
 )
 
 // openNewIssueForm opens the new issue form
@@ -31,8 +34,8 @@ func (m Model) openNewIssueForm() (tea.Model, tea.Cmd) {
 	m.FormState.Width = formWidth
 	m.FormState.Form.WithWidth(formWidth)
 
-	// Initialize the form
-	return m, m.FormState.Form.Init()
+	// Initialize the form and load autofill data
+	return m, tea.Batch(m.FormState.Form.Init(), loadAutofillData(m.DB))
 }
 
 // openEditIssueForm opens the edit form for the selected/modal issue
@@ -59,14 +62,21 @@ func (m Model) openEditIssueForm() (tea.Model, tea.Cmd) {
 	m.FormState = NewFormStateForEdit(issue)
 	m.FormOpen = true
 
+	// Pre-populate dependencies from the database
+	depIDs, _ := m.DB.GetDependencies(issue.ID)
+	if len(depIDs) > 0 {
+		m.FormState.Dependencies = strings.Join(depIDs, ", ")
+		m.FormState.buildForm()
+	}
+
 	// Set form width for text wrapping (subtract modal horizontal padding)
 	modalWidth, _ := m.formModalDimensions()
 	formWidth := modalWidth - 4
 	m.FormState.Width = formWidth
 	m.FormState.Form.WithWidth(formWidth)
 
-	// Initialize the form
-	return m, m.FormState.Form.Init()
+	// Initialize the form and load autofill data
+	return m, tea.Batch(m.FormState.Form.Init(), loadAutofillData(m.DB))
 }
 
 // closeForm closes the form modal and clears state
@@ -111,6 +121,29 @@ func (m Model) submitForm() (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
+		// Detect status change
+		oldStatus := existingIssue.Status
+		newStatus := models.Status(m.FormState.Status)
+		statusChanged := oldStatus != newStatus
+
+		// Validate status transition if changed
+		if statusChanged {
+			sm := workflow.DefaultMachine()
+			if !sm.IsValidTransition(oldStatus, newStatus) {
+				m.StatusMessage = fmt.Sprintf("Invalid transition: %s → %s", oldStatus, newStatus)
+				m.StatusIsError = true
+				return m, tea.Tick(2*time.Second, func(t time.Time) tea.Msg {
+					return ClearStatusMsg{}
+				})
+			}
+		}
+
+		// Determine action type based on status transition
+		actionType := models.ActionUpdate
+		if statusChanged {
+			actionType = statusTransitionAction(oldStatus, newStatus)
+		}
+
 		// Update fields
 		existingIssue.Title = issue.Title
 		existingIssue.Type = issue.Type
@@ -122,9 +155,70 @@ func (m Model) submitForm() (tea.Model, tea.Cmd) {
 		existingIssue.Acceptance = issue.Acceptance
 		existingIssue.Minor = issue.Minor
 
-		if err := m.DB.UpdateIssueLogged(existingIssue, m.SessionID, models.ActionUpdate); err != nil {
+		// Apply status change with associated field updates
+		if statusChanged {
+			existingIssue.Status = newStatus
+
+			switch {
+			case newStatus == models.StatusClosed:
+				now := time.Now()
+				existingIssue.ClosedAt = &now
+			case oldStatus == models.StatusClosed:
+				// Reopening: clear close metadata
+				existingIssue.ClosedAt = nil
+				existingIssue.ReviewerSession = ""
+			}
+
+			if newStatus == models.StatusInReview && existingIssue.ImplementerSession == "" {
+				existingIssue.ImplementerSession = m.SessionID
+			}
+		}
+
+		if err := m.DB.UpdateIssueLogged(existingIssue, m.SessionID, actionType); err != nil {
 			m.Err = err
 			return m, nil
+		}
+
+		// Sync dependencies: diff old vs new, add/remove as needed
+		newDeps := m.FormState.GetDependencies()
+		oldDeps, _ := m.DB.GetDependencies(m.FormState.IssueID)
+		oldSet := make(map[string]bool, len(oldDeps))
+		for _, id := range oldDeps {
+			oldSet[id] = true
+		}
+		newSet := make(map[string]bool, len(newDeps))
+		for _, id := range newDeps {
+			if id != "" {
+				newSet[id] = true
+			}
+		}
+		// Remove deps that were deleted
+		for _, id := range oldDeps {
+			if !newSet[id] {
+				_ = m.DB.RemoveDependencyLogged(m.FormState.IssueID, id, m.SessionID)
+			}
+		}
+		// Add deps that are new
+		for _, id := range newDeps {
+			if id != "" && !oldSet[id] {
+				_ = m.DB.AddDependencyLogged(m.FormState.IssueID, id, "depends_on", m.SessionID)
+			}
+		}
+
+		// Record session action for bypass prevention
+		if statusChanged {
+			var sessionAction models.IssueSessionAction
+			switch {
+			case oldStatus == models.StatusOpen && newStatus == models.StatusInProgress:
+				sessionAction = models.ActionSessionStarted
+			case oldStatus == models.StatusInProgress && newStatus == models.StatusOpen:
+				sessionAction = models.ActionSessionUnstarted
+			case oldStatus == models.StatusInReview && newStatus == models.StatusClosed:
+				sessionAction = models.ActionSessionReviewed
+			}
+			if sessionAction != "" {
+				m.DB.RecordSessionAction(existingIssue.ID, m.SessionID, sessionAction)
+			}
 		}
 
 		m.closeForm()
@@ -251,4 +345,25 @@ func (m Model) handleEditorFinished(msg EditorFinishedMsg) (tea.Model, tea.Cmd) 
 			return ClearStatusMsg{}
 		}),
 	)
+}
+
+// statusTransitionAction returns the appropriate ActionType for a status transition.
+// Uses specific action types for well-known transitions to produce meaningful activity log entries.
+func statusTransitionAction(from, to models.Status) models.ActionType {
+	switch {
+	case from == models.StatusOpen && to == models.StatusInProgress:
+		return models.ActionStart
+	case to == models.StatusInReview:
+		return models.ActionReview
+	case to == models.StatusClosed:
+		return models.ActionClose
+	case from == models.StatusClosed && to == models.StatusOpen:
+		return models.ActionReopen
+	case to == models.StatusBlocked:
+		return models.ActionBlock
+	case from == models.StatusBlocked && (to == models.StatusOpen || to == models.StatusInProgress):
+		return models.ActionUnblock
+	default:
+		return models.ActionUpdate
+	}
 }


### PR DESCRIPTION
## Summary

- **Autofill dropdowns** for Parent Epic and Dependencies form fields with fzf-style fuzzy search (sahilm/fuzzy), inline rendering below the focused field, and proper lifecycle management (dismiss on blur, Esc, selection, tab-to-buttons)
- **Inline status editing** in the edit form (press `e`) with workflow validation via `workflow.DefaultMachine()`, side-effect application (ClosedAt, ReviewerSession, ImplementerSession), and session action recording
- **Dependency sync on edit** — pre-populates existing dependencies and diffs old vs new on submit (add/remove)
- **Dynamic content-based modal height** — modal sizes to its content per tab instead of using a fixed height percentage
- **Board view refresh fix** — board now properly refreshes after task creation, status changes, and other actions

## Key implementation details

- Autofill dropdown is rendered by post-processing huh's `Form.View()` output and injecting the dropdown inline using ANSI-safe title scanning (`insertDropdownAfterField`)
- Focus restoration after autofill selection avoids `tea.Batch` cmd race between `Init()` and `NextGroup()` by calling Init synchronously and discarding its async cmd
- Esc key is guarded so it dismisses the dropdown first before canceling the form
- `isExactAutofillID()` prevents the dropdown from re-activating immediately after selection
- `syncAutofillState()` detects focused field changes and activates/deactivates the dropdown accordingly

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/monitor/...` passes (21 new tests for autofill utilities)
- [x] `go vet ./...` passes
- [ ] Manual: Open create form → Ctrl+X → focus Parent Epic → autofill dropdown appears with fuzzy search
- [ ] Manual: Select autofill item → dropdown closes, modal shrinks to current tab height, focus stays on field
- [ ] Manual: Tab from Dependencies to Submit → dropdown closes, Enter submits form
- [ ] Manual: Esc with dropdown active → dropdown dismisses (form stays open)
- [ ] Manual: Edit form (`e`) → Ctrl+X → Status field appears on Workflow tab → change status → validates transition
- [ ] Manual: Edit form with dependencies → existing deps pre-populated → modify → submit syncs changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)