### PR TITLE
feat: add IN_PROGRESS and PENDING_REVIEW categories to board view

### DIFF
--- a/pkg/monitor/input.go
+++ b/pkg/monitor/input.go
@@ -448,15 +448,21 @@ func (m *Model) buildCurrentWorkRows() {
 // buildTaskListRows builds the flattened list of task list rows with category metadata
 func (m *Model) buildTaskListRows() {
 	m.TaskListRows = nil
-	// Order: Reviewable, NeedsRework, Ready, Blocked, Closed (matches display order)
+	// Order: Reviewable, NeedsRework, InProgress, Ready, PendingReview, Blocked, Closed
 	for _, issue := range m.TaskList.Reviewable {
 		m.TaskListRows = append(m.TaskListRows, TaskListRow{Issue: issue, Category: CategoryReviewable})
 	}
 	for _, issue := range m.TaskList.NeedsRework {
 		m.TaskListRows = append(m.TaskListRows, TaskListRow{Issue: issue, Category: CategoryNeedsRework})
 	}
+	for _, issue := range m.TaskList.InProgress {
+		m.TaskListRows = append(m.TaskListRows, TaskListRow{Issue: issue, Category: CategoryInProgress})
+	}
 	for _, issue := range m.TaskList.Ready {
 		m.TaskListRows = append(m.TaskListRows, TaskListRow{Issue: issue, Category: CategoryReady})
+	}
+	for _, issue := range m.TaskList.PendingReview {
+		m.TaskListRows = append(m.TaskListRows, TaskListRow{Issue: issue, Category: CategoryPendingReview})
 	}
 	for _, issue := range m.TaskList.Blocked {
 		m.TaskListRows = append(m.TaskListRows, TaskListRow{Issue: issue, Category: CategoryBlocked})

--- a/pkg/monitor/model_test.go
+++ b/pkg/monitor/model_test.go
@@ -176,16 +176,18 @@ func TestSelectedIssueIDEmptyLists(t *testing.T) {
 func TestBuildTaskListRows(t *testing.T) {
 	m := Model{
 		TaskList: TaskListData{
-			Reviewable:  []models.Issue{{ID: "r1"}, {ID: "r2"}},
-			NeedsRework: []models.Issue{{ID: "rw1"}},
-			Ready:       []models.Issue{{ID: "rd1"}},
-			Blocked:     []models.Issue{{ID: "b1"}, {ID: "b2"}, {ID: "b3"}},
+			Reviewable:    []models.Issue{{ID: "r1"}, {ID: "r2"}},
+			NeedsRework:   []models.Issue{{ID: "rw1"}},
+			InProgress:    []models.Issue{{ID: "ip1"}},
+			Ready:         []models.Issue{{ID: "rd1"}},
+			PendingReview: []models.Issue{{ID: "pr1"}},
+			Blocked:       []models.Issue{{ID: "b1"}, {ID: "b2"}, {ID: "b3"}},
 		},
 	}
 
 	m.buildTaskListRows()
 
-	// Order should be: Reviewable, NeedsRework, Ready, Blocked
+	// Order should be: Reviewable, NeedsRework, InProgress, Ready, PendingReview, Blocked
 	expected := []struct {
 		id       string
 		category TaskListCategory
@@ -193,7 +195,9 @@ func TestBuildTaskListRows(t *testing.T) {
 		{"r1", CategoryReviewable},
 		{"r2", CategoryReviewable},
 		{"rw1", CategoryNeedsRework},
+		{"ip1", CategoryInProgress},
 		{"rd1", CategoryReady},
+		{"pr1", CategoryPendingReview},
 		{"b1", CategoryBlocked},
 		{"b2", CategoryBlocked},
 		{"b3", CategoryBlocked},

--- a/pkg/monitor/types.go
+++ b/pkg/monitor/types.go
@@ -238,11 +238,13 @@ func updateQueryType(query string, typeMode TypeFilterMode) string {
 type TaskListCategory string
 
 const (
-	CategoryReviewable  TaskListCategory = "REVIEW"
-	CategoryNeedsRework TaskListCategory = "REWORK"
-	CategoryReady       TaskListCategory = "READY"
-	CategoryBlocked     TaskListCategory = "BLOCKED"
-	CategoryClosed      TaskListCategory = "CLOSED"
+	CategoryReviewable    TaskListCategory = "REVIEW"
+	CategoryNeedsRework   TaskListCategory = "REWORK"
+	CategoryInProgress    TaskListCategory = "IN_PROGRESS"
+	CategoryReady         TaskListCategory = "READY"
+	CategoryPendingReview TaskListCategory = "PENDING_REVIEW"
+	CategoryBlocked       TaskListCategory = "BLOCKED"
+	CategoryClosed        TaskListCategory = "CLOSED"
 )
 
 // ActivityItem represents a unified activity item (log, action, or comment)
@@ -259,11 +261,13 @@ type ActivityItem struct {
 
 // TaskListData holds categorized issues for the task list panel
 type TaskListData struct {
-	Ready       []models.Issue
-	Reviewable  []models.Issue
-	NeedsRework []models.Issue
-	Blocked     []models.Issue
-	Closed      []models.Issue
+	Reviewable    []models.Issue
+	NeedsRework   []models.Issue
+	InProgress    []models.Issue // in_progress, not rejected
+	Ready         []models.Issue // open, not blocked
+	PendingReview []models.Issue // in_review, own implementation
+	Blocked       []models.Issue
+	Closed        []models.Issue
 }
 
 // TaskListRow represents a single selectable row in the task list panel

--- a/pkg/monitor/view.go
+++ b/pkg/monitor/view.go
@@ -175,10 +175,12 @@ func (m Model) renderCompact() string {
 	}
 
 	s.WriteString(fmt.Sprintf("In Progress: %d\n", len(m.InProgress)))
-	s.WriteString(fmt.Sprintf("Ready: %d | Review: %d | Rework: %d | Blocked: %d\n",
+	s.WriteString(fmt.Sprintf("Ready: %d | WIP: %d | Review: %d | Rework: %d | PRev: %d | Blocked: %d\n",
 		len(m.TaskList.Ready),
+		len(m.TaskList.InProgress),
 		len(m.TaskList.Reviewable),
 		len(m.TaskList.NeedsRework),
+		len(m.TaskList.PendingReview),
 		len(m.TaskList.Blocked)))
 
 	s.WriteString("\nq:quit r:refresh ?:help")
@@ -922,9 +924,15 @@ func (m Model) formatSwimlaneCategoryHeader(cat TaskListCategory) string {
 	case CategoryNeedsRework:
 		count = len(m.BoardMode.SwimlaneData.NeedsRework)
 		return reworkColor.Render("⚠ NEEDS REWORK") + fmt.Sprintf(" (%d):", count)
+	case CategoryInProgress:
+		count = len(m.BoardMode.SwimlaneData.InProgress)
+		return inProgressHeaderStyle.Render("IN PROGRESS") + fmt.Sprintf(" (%d):", count)
 	case CategoryReady:
 		count = len(m.BoardMode.SwimlaneData.Ready)
 		return readyHeaderStyle.Render("READY") + fmt.Sprintf(" (%d):", count)
+	case CategoryPendingReview:
+		count = len(m.BoardMode.SwimlaneData.PendingReview)
+		return pendingReviewHeaderStyle.Render("PENDING REVIEW") + fmt.Sprintf(" (%d):", count)
 	case CategoryBlocked:
 		count = len(m.BoardMode.SwimlaneData.Blocked)
 		return blockedHeaderStyle.Render("BLOCKED") + fmt.Sprintf(" (%d):", count)
@@ -945,9 +953,15 @@ func (m Model) formatCategoryHeader(cat TaskListCategory) string {
 	case CategoryNeedsRework:
 		count = len(m.TaskList.NeedsRework)
 		return reworkColor.Render("⚠ NEEDS REWORK") + fmt.Sprintf(" (%d):", count)
+	case CategoryInProgress:
+		count = len(m.TaskList.InProgress)
+		return inProgressHeaderStyle.Render("IN PROGRESS") + fmt.Sprintf(" (%d):", count)
 	case CategoryReady:
 		count = len(m.TaskList.Ready)
 		return readyHeaderStyle.Render("READY") + fmt.Sprintf(" (%d):", count)
+	case CategoryPendingReview:
+		count = len(m.TaskList.PendingReview)
+		return pendingReviewHeaderStyle.Render("PENDING REVIEW") + fmt.Sprintf(" (%d):", count)
 	case CategoryBlocked:
 		count = len(m.TaskList.Blocked)
 		return blockedHeaderStyle.Render("BLOCKED") + fmt.Sprintf(" (%d):", count)
@@ -965,8 +979,12 @@ func (m Model) formatCategoryTag(cat TaskListCategory) string {
 		return reviewColor.Render("[REV]")
 	case CategoryNeedsRework:
 		return reworkColor.Render("[RWK]")
+	case CategoryInProgress:
+		return inProgressColor.Render("[WIP]")
 	case CategoryReady:
 		return readyColor.Render("[RDY]")
+	case CategoryPendingReview:
+		return pendingReviewColor.Render("[PRV]")
 	case CategoryBlocked:
 		return blockedColor.Render("[BLK]")
 	case CategoryClosed:
@@ -2353,10 +2371,12 @@ func truncateSession(sessionID string) string {
 
 // Color styles for task list sections
 var (
-	readyColor   = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
-	reviewColor  = lipgloss.NewStyle().Foreground(lipgloss.Color("141"))
-	blockedColor = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
-	reworkColor  = lipgloss.NewStyle().Foreground(lipgloss.Color("214")) // Orange/warning
+	readyColor         = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))
+	reviewColor        = lipgloss.NewStyle().Foreground(lipgloss.Color("141"))
+	blockedColor       = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+	reworkColor        = lipgloss.NewStyle().Foreground(lipgloss.Color("214")) // Orange/warning
+	inProgressColor    = lipgloss.NewStyle().Foreground(lipgloss.Color("45"))  // Cyan
+	pendingReviewColor = lipgloss.NewStyle().Foreground(lipgloss.Color("183")) // Light purple
 
 	// Prominent style for review alert in footer
 	reviewAlertStyle = lipgloss.NewStyle().
@@ -2374,6 +2394,16 @@ var (
 				Bold(true).
 				Foreground(lipgloss.Color("255")).
 				Background(lipgloss.Color("196")) // Red bg
+
+	inProgressHeaderStyle = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("0")).
+				Background(lipgloss.Color("45")) // Cyan bg
+
+	pendingReviewHeaderStyle = lipgloss.NewStyle().
+					Bold(true).
+					Foreground(lipgloss.Color("0")).
+					Background(lipgloss.Color("183")) // Light purple bg
 
 	// Prominent style for handoff alert - green background
 	handoffAlertStyle = lipgloss.NewStyle().


### PR DESCRIPTION
## Summary

- Adds `CategoryInProgress` (`[WIP]`, cyan) and `CategoryPendingReview` (`[PRV]`, light purple) to the monitor board view
- Splits the overloaded `READY` category which previously conflated `open`, `in_progress`, and own `in_review` tasks into distinct sections
- Fixes a bug where own `in_review` tasks were silently dropped in non-board/TDQ mode

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages including e2e)
- [x] Verified all 7 categories display correctly in sidecar td tab with real tasks
- [ ] Manual: toggle board/swimlanes/backlog views, verify category tags and headers
- [ ] Manual: verify compact view shows updated counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)