### PR TITLE
fix: remove accidentally committed .td-root file

### DIFF
--- a/.td-root
+++ b/.td-root
@@ -1,1 +1,0 @@
-/Users/marcusvorwaller/code/td


### PR DESCRIPTION
## Summary

- Removes the `.td-root` file that was accidentally committed in 4f79760
- The file contains a hardcoded absolute path (`/Users/marcusvorwaller/code/td`) which causes `td init` to fail with `permission denied` for all other users
- The file is already in `.gitignore` so it should never have been tracked

## Problem

```
$ td init
ERROR: failed to initialize database: create db dir: mkdir /Users/marcusvorwaller: permission denied
```

`ResolveBaseDir()` reads `.td-root` and redirects the database path to the hardcoded directory, which doesn't exist on other machines.

## Test plan

- [ ] Run `td init` in a fresh clone — should succeed without permission errors
- [ ] Verify `.td-root` is no longer tracked (`git ls-files -- .td-root` returns empty)
- [ ] Verify `.gitignore` still covers `.td-root` for future protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)