### PR TITLE
feat: export database access for embedders

### DIFF
--- a/pkg/monitor/dbpool.go
+++ b/pkg/monitor/dbpool.go
@@ -88,6 +88,20 @@ func releaseSharedDB(baseDir string) error {
 	return nil
 }
 
+// OpenDB opens a shared database connection for the given project directory.
+// The connection is reference-counted and cached — multiple callers sharing
+// the same baseDir get the same underlying connection.
+// Callers must call CloseDB with the same baseDir when done.
+func OpenDB(baseDir string) (*db.DB, error) {
+	return getSharedDB(baseDir)
+}
+
+// CloseDB releases a shared database connection opened with OpenDB.
+// The underlying connection is closed when all references are released.
+func CloseDB(baseDir string) error {
+	return releaseSharedDB(baseDir)
+}
+
 // clearDBPool closes all shared connections and clears the pool.
 // This is primarily for testing purposes.
 func clearDBPool() {


### PR DESCRIPTION
## Summary

- Export `OpenDB` / `CloseDB` functions in `pkg/monitor/dbpool.go` to give embedders access to the shared, reference-counted database pool
- Add `ProjectSummary` struct and `FetchProjectSummary()` in `pkg/monitor/data.go` for lightweight multi-project dashboard stats (issue counts by status, focused issue, last activity)

These are needed by sidecar's new projects dashboard plugin to query td stats across multiple projects without creating full embedded monitors for each.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./pkg/monitor/...` passes
- [ ] Existing monitor functionality unaffected (no changes to existing APIs)
- [ ] Verify `OpenDB`/`CloseDB` properly delegates to existing `getSharedDB`/`releaseSharedDB`

🤖 Generated with [Claude Code](https://claude.com/claude-code)