### PR TITLE
fix(db): normalize action_log timestamp writes to RFC3339Nano UTC

### DIFF
--- a/internal/db/action_log_time.go
+++ b/internal/db/action_log_time.go
@@ -1,0 +1,13 @@
+package db
+
+import "time"
+
+// actionLogTimestampNow returns the canonical action_log timestamp format:
+// UTC RFC3339Nano text for reliable SQLite lexicographic comparisons.
+func actionLogTimestampNow() string {
+	return formatActionLogTimestamp(time.Now())
+}
+
+func formatActionLogTimestamp(t time.Time) string {
+	return t.UTC().Format(time.RFC3339Nano)
+}

--- a/internal/db/action_log_time_test.go
+++ b/internal/db/action_log_time_test.go
@@ -1,0 +1,84 @@
+package db
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/marcus/td/internal/models"
+)
+
+func TestActionLogTimestampHelpers(t *testing.T) {
+	ts := actionLogTimestampNow()
+	parsed, err := time.Parse(time.RFC3339Nano, ts)
+	if err != nil {
+		t.Fatalf("actionLogTimestampNow not RFC3339Nano: %v (%q)", err, ts)
+	}
+	if !parsed.Equal(parsed.UTC()) {
+		t.Fatalf("expected UTC timestamp, got %q", ts)
+	}
+	if !strings.Contains(ts, "T") || !strings.HasSuffix(ts, "Z") {
+		t.Fatalf("expected RFC3339 UTC shape, got %q", ts)
+	}
+}
+
+func TestActionLogWritesUseCanonicalTimestampFormat(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Initialize(dir)
+	if err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+	defer db.Close()
+
+	issue := &models.Issue{Title: "Test Issue"}
+	if err := db.CreateIssue(issue); err != nil {
+		t.Fatalf("CreateIssue failed: %v", err)
+	}
+
+	if err := db.LogAction(&models.ActionLog{
+		SessionID:    "ses_test",
+		ActionType:   models.ActionUpdate,
+		EntityType:   "issue",
+		EntityID:     issue.ID,
+		PreviousData: `{}`,
+		NewData:      `{"status":"in_progress"}`,
+	}); err != nil {
+		t.Fatalf("LogAction failed: %v", err)
+	}
+
+	if err := db.AddDependencyLogged(issue.ID, "td-999", "depends_on", "ses_test"); err != nil {
+		t.Fatalf("AddDependencyLogged failed: %v", err)
+	}
+
+	if _, err := db.CreateNote("n1", "body"); err != nil {
+		t.Fatalf("CreateNote failed: %v", err)
+	}
+
+	rows, err := db.conn.Query(`SELECT CAST(timestamp AS TEXT) FROM action_log ORDER BY rowid ASC`)
+	if err != nil {
+		t.Fatalf("query action_log timestamps: %v", err)
+	}
+	defer rows.Close()
+
+	count := 0
+	for rows.Next() {
+		var ts string
+		if err := rows.Scan(&ts); err != nil {
+			t.Fatalf("scan timestamp: %v", err)
+		}
+		count++
+
+		if _, err := time.Parse(time.RFC3339Nano, ts); err != nil {
+			t.Fatalf("timestamp %q is not RFC3339Nano: %v", ts, err)
+		}
+		if !strings.Contains(ts, "T") || !strings.HasSuffix(ts, "Z") {
+			t.Fatalf("timestamp not canonical RFC3339 UTC: %q", ts)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate timestamps: %v", err)
+	}
+	if count < 3 {
+		t.Fatalf("expected at least 3 action_log rows, got %d", count)
+	}
+}

--- a/internal/db/boards_logged.go
+++ b/internal/db/boards_logged.go
@@ -64,8 +64,9 @@ func (db *DB) CreateBoardLogged(name, queryStr, sessionID string) (*models.Board
 			return fmt.Errorf("generate action ID: %w", err)
 		}
 		newData := marshalBoard(board)
+		actionTS := formatActionLogTimestamp(now)
 		_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, sessionID, string(models.ActionBoardCreate), "board", board.ID, "", newData, now)
+			actionID, sessionID, string(models.ActionBoardCreate), "board", board.ID, "", newData, actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}
@@ -112,8 +113,9 @@ func (db *DB) UpdateBoardLogged(board *models.Board, sessionID string) error {
 			return fmt.Errorf("generate action ID: %w", err)
 		}
 		newData := marshalBoard(board)
+		actionTS := formatActionLogTimestamp(board.UpdatedAt)
 		_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, sessionID, string(models.ActionBoardUpdate), "board", board.ID, previousData, newData, board.UpdatedAt)
+			actionID, sessionID, string(models.ActionBoardUpdate), "board", board.ID, previousData, newData, actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}
@@ -163,8 +165,9 @@ func (db *DB) SetIssuePositionLogged(boardID, issueID string, position int, sess
 			"id": bipID, "board_id": boardID, "issue_id": issueID,
 			"position": position, "added_at": now.UTC().Format("2006-01-02T15:04:05Z07:00"),
 		})
+		actionTS := formatActionLogTimestamp(now)
 		_, err = tx.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, sessionID, string(models.ActionBoardSetPosition), "board_issue_positions", bipID, "", string(newData), now)
+			actionID, sessionID, string(models.ActionBoardSetPosition), "board_issue_positions", bipID, "", string(newData), actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}
@@ -205,8 +208,9 @@ func (db *DB) RemoveIssuePositionLogged(boardID, issueID, sessionID string) erro
 		if err != nil {
 			return fmt.Errorf("generate action ID: %w", err)
 		}
+		actionTS := formatActionLogTimestamp(now)
 		_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, sessionID, string(models.ActionBoardUnposition), "board_issue_positions", bipID, string(prevData), "", now)
+			actionID, sessionID, string(models.ActionBoardUnposition), "board_issue_positions", bipID, string(prevData), "", actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}
@@ -266,8 +270,9 @@ func (db *DB) DeleteBoardLogged(boardID, sessionID string) error {
 			if err != nil {
 				return fmt.Errorf("generate action ID: %w", err)
 			}
+			actionTS := formatActionLogTimestamp(now)
 			_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-				posActionID, sessionID, string(models.ActionBoardUnposition), "board_issue_positions", bipID, string(prevData), "", now)
+				posActionID, sessionID, string(models.ActionBoardUnposition), "board_issue_positions", bipID, string(prevData), "", actionTS)
 			if err != nil {
 				return fmt.Errorf("log position action: %w", err)
 			}
@@ -284,8 +289,9 @@ func (db *DB) DeleteBoardLogged(boardID, sessionID string) error {
 		if err != nil {
 			return fmt.Errorf("generate action ID: %w", err)
 		}
+		actionTS := formatActionLogTimestamp(now)
 		_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, sessionID, string(models.ActionBoardDelete), "board", boardID, previousData, "", now)
+			actionID, sessionID, string(models.ActionBoardDelete), "board", boardID, previousData, "", actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}

--- a/internal/db/issues_logged.go
+++ b/internal/db/issues_logged.go
@@ -131,8 +131,9 @@ func (db *DB) CreateIssueLogged(issue *models.Issue, sessionID string) error {
 			return fmt.Errorf("generate action ID: %w", err)
 		}
 		newData := marshalIssue(issue)
+		actionTS := formatActionLogTimestamp(now)
 		_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, sessionID, string(models.ActionCreate), "issue", issue.ID, "", newData, now)
+			actionID, sessionID, string(models.ActionCreate), "issue", issue.ID, "", newData, actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}
@@ -187,8 +188,9 @@ func (db *DB) updateIssueAndLog(issue *models.Issue, sessionID string, actionTyp
 		return fmt.Errorf("generate action ID: %w", err)
 	}
 	newData := marshalIssue(issue)
+	actionTS := formatActionLogTimestamp(issue.UpdatedAt)
 	_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-		actionID, sessionID, string(actionType), "issue", issue.ID, previousData, newData, issue.UpdatedAt)
+		actionID, sessionID, string(actionType), "issue", issue.ID, previousData, newData, actionTS)
 	if err != nil {
 		return fmt.Errorf("log action: %w", err)
 	}
@@ -241,8 +243,9 @@ func (db *DB) DeleteIssueLogged(issueID, sessionID string) error {
 		if err != nil {
 			return fmt.Errorf("generate action ID: %w", err)
 		}
+		actionTS := formatActionLogTimestamp(now)
 		_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, sessionID, string(models.ActionDelete), "issue", issueID, previousData, "", now)
+			actionID, sessionID, string(models.ActionDelete), "issue", issueID, previousData, "", actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}
@@ -280,8 +283,9 @@ func (db *DB) RestoreIssueLogged(issueID, sessionID string) error {
 		if err != nil {
 			return fmt.Errorf("generate action ID: %w", err)
 		}
+		actionTS := formatActionLogTimestamp(now)
 		_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, sessionID, string(models.ActionRestore), "issue", issueID, previousData, newData, now)
+			actionID, sessionID, string(models.ActionRestore), "issue", issueID, previousData, newData, actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}

--- a/internal/db/notes.go
+++ b/internal/db/notes.go
@@ -98,8 +98,9 @@ func (db *DB) CreateNote(title, content string) (*models.Note, error) {
 			return fmt.Errorf("generate action ID: %w", err)
 		}
 		newData := marshalNote(&note)
+		actionTS := formatActionLogTimestamp(now)
 		_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, "", string(models.ActionCreate), "note", note.ID, "", newData, now)
+			actionID, "", string(models.ActionCreate), "note", note.ID, "", newData, actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}
@@ -239,8 +240,9 @@ func (db *DB) UpdateNote(id, title, content string) (*models.Note, error) {
 			return fmt.Errorf("generate action ID: %w", err)
 		}
 		newData := marshalNote(&updated)
+		actionTS := formatActionLogTimestamp(now)
 		_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, "", string(models.ActionUpdate), "note", id, previousData, newData, now)
+			actionID, "", string(models.ActionUpdate), "note", id, previousData, newData, actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}
@@ -278,8 +280,9 @@ func (db *DB) DeleteNote(id string) error {
 		if err != nil {
 			return fmt.Errorf("generate action ID: %w", err)
 		}
+		actionTS := formatActionLogTimestamp(now)
 		_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, "", string(models.ActionDelete), "note", id, previousData, "", now)
+			actionID, "", string(models.ActionDelete), "note", id, previousData, "", actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}

--- a/internal/db/relations_logged.go
+++ b/internal/db/relations_logged.go
@@ -35,8 +35,9 @@ func (db *DB) AddDependencyLogged(issueID, dependsOnID, relationType, sessionID 
 		}
 		now := time.Now()
 		newData := marshalDependency(depID, issueID, dependsOnID, relationType)
+		actionTS := formatActionLogTimestamp(now)
 		_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, sessionID, string(models.ActionAddDep), "issue_dependencies", depID, "", newData, now)
+			actionID, sessionID, string(models.ActionAddDep), "issue_dependencies", depID, "", newData, actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}
@@ -71,8 +72,9 @@ func (db *DB) LinkFileLogged(issueID, filePath string, role models.FileRole, sha
 			return fmt.Errorf("generate action ID: %w", err)
 		}
 		newData := marshalFileLink(id, issueID, filePath, string(role), sha, now.Format(time.RFC3339))
+		actionTS := formatActionLogTimestamp(now)
 		_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, sessionID, string(models.ActionLinkFile), "issue_files", id, "", newData, now)
+			actionID, sessionID, string(models.ActionLinkFile), "issue_files", id, "", newData, actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}
@@ -105,8 +107,9 @@ func (db *DB) UnlinkFileLogged(issueID, filePath, sessionID string) error {
 			return fmt.Errorf("generate action ID: %w", err)
 		}
 		now := time.Now()
+		actionTS := formatActionLogTimestamp(now)
 		_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, sessionID, string(models.ActionUnlinkFile), "issue_files", id, previousData, "", now)
+			actionID, sessionID, string(models.ActionUnlinkFile), "issue_files", id, previousData, "", actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}
@@ -132,8 +135,9 @@ func (db *DB) RemoveDependencyLogged(issueID, dependsOnID, sessionID string) err
 			return fmt.Errorf("generate action ID: %w", err)
 		}
 		now := time.Now()
+		actionTS := formatActionLogTimestamp(now)
 		_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, sessionID, string(models.ActionRemoveDep), "issue_dependencies", depID, previousData, "", now)
+			actionID, sessionID, string(models.ActionRemoveDep), "issue_dependencies", depID, previousData, "", actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}

--- a/internal/db/work_sessions.go
+++ b/internal/db/work_sessions.go
@@ -35,8 +35,9 @@ func (db *DB) CreateWorkSession(ws *models.WorkSession) error {
 			"id": ws.ID, "name": ws.Name, "session_id": ws.SessionID,
 			"started_at": ws.StartedAt, "start_sha": ws.StartSHA,
 		})
+		actionTS := actionLogTimestampNow()
 		_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, ws.SessionID, "create", "work_sessions", ws.ID, "", string(newData), time.Now())
+			actionID, ws.SessionID, "create", "work_sessions", ws.ID, "", string(newData), actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}
@@ -89,8 +90,9 @@ func (db *DB) UpdateWorkSession(ws *models.WorkSession) error {
 			"started_at": ws.StartedAt, "ended_at": ws.EndedAt,
 			"start_sha": ws.StartSHA, "end_sha": ws.EndSHA,
 		})
+		actionTS := actionLogTimestampNow()
 		_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, ws.SessionID, "update", "work_sessions", ws.ID, "", string(newData), time.Now())
+			actionID, ws.SessionID, "update", "work_sessions", ws.ID, "", string(newData), actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}
@@ -119,8 +121,9 @@ func (db *DB) TagIssueToWorkSession(wsID, issueID, sessionID string) error {
 		newData, _ := json.Marshal(map[string]interface{}{
 			"id": id, "work_session_id": wsID, "issue_id": issueID, "tagged_at": now,
 		})
+		actionTS := formatActionLogTimestamp(now)
 		_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, sessionID, string(models.ActionWorkSessionTag), "work_session_issues", id, "", string(newData), now)
+			actionID, sessionID, string(models.ActionWorkSessionTag), "work_session_issues", id, "", string(newData), actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}
@@ -145,8 +148,9 @@ func (db *DB) UntagIssueFromWorkSession(wsID, issueID, sessionID string) error {
 		newData, _ := json.Marshal(map[string]interface{}{
 			"id": id, "work_session_id": wsID, "issue_id": issueID,
 		})
+		actionTS := actionLogTimestampNow()
 		_, err = db.conn.Exec(`INSERT INTO action_log (id, session_id, action_type, entity_type, entity_id, previous_data, new_data, timestamp, undone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
-			actionID, sessionID, string(models.ActionWorkSessionUntag), "work_session_issues", id, "", string(newData), time.Now())
+			actionID, sessionID, string(models.ActionWorkSessionUntag), "work_session_issues", id, "", string(newData), actionTS)
 		if err != nil {
 			return fmt.Errorf("log action: %w", err)
 		}


### PR DESCRIPTION
- add centralized action_log timestamp helpers:
  - actionLogTimestampNow()
  - formatActionLogTimestamp(time.Time)
- update all local non-test action_log INSERT callsites to write canonical UTC RFC3339Nano strings instead of driver-serialized time.Time values:
  - internal/db/activity.go
  - internal/db/issues_logged.go
  - internal/db/boards_logged.go
  - internal/db/relations_logged.go
  - internal/db/work_sessions.go
  - internal/db/notes.go
- add regression tests to verify helper output and stored action_log timestamps are RFC3339Nano UTC text

Validation:
- go test ./internal/db/...