### PR TITLE
Add pre-commit hook and make install-hooks target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt test install tag release check-clean check-version
+.PHONY: help fmt test install tag release check-clean check-version install-hooks
 
 SHELL := /bin/sh
 
@@ -13,6 +13,7 @@ help:
 	@printf "%s\n" \
 		"Targets:" \
 		"  make fmt                       # gofmt -w ." \
+		"  make install-hooks             # install git pre-commit hook" \
 		"  make test                      # go test ./..." \
 		"  make install                   # build and install with version from git" \
 		"  make tag VERSION=vX.Y.Z        # create annotated git tag (requires clean tree)" \
@@ -49,3 +50,8 @@ tag: check-clean check-version
 release: tag
 	@git remote get-url origin >/dev/null 2>&1 || (echo "Error: no 'origin' remote configured" && exit 1)
 	git push origin "$(VERSION)"
+
+install-hooks:
+	@echo "Installing git pre-commit hook..."
+	@ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit
+	@echo "Done. Hook installed at .git/hooks/pre-commit"

--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ make install-dev
 
 # Format code
 make fmt
+
+# Install git pre-commit hook (gofmt, go vet, go build on staged files)
+make install-hooks
 ```
 
 ## Tests & Quality Checks

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# pre-commit hook for td
+# Install: make install-hooks  (or: ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit)
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+echo "🪡 pre-commit checks"
+
+# --- gofmt: only staged .go files ---
+STAGED_GO=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$' || true)
+
+if [[ -n "$STAGED_GO" ]]; then
+  printf "  %-20s" "gofmt"
+  UNFORMATTED=$(echo "$STAGED_GO" | xargs gofmt -l 2>&1)
+  if [[ -z "$UNFORMATTED" ]]; then
+    echo "✓"
+    PASS=$((PASS+1))
+  else
+    echo "✗ FAILED — run: gofmt -w ."
+    echo "$UNFORMATTED" | sed 's/^/    /'
+    FAIL=$((FAIL+1))
+  fi
+else
+  printf "  %-20s" "gofmt"
+  echo "– (no .go files staged)"
+fi
+
+# --- go vet ---
+printf "  %-20s" "go vet"
+VET_OUT=$(go vet ./... 2>&1)
+if [[ $? -eq 0 ]]; then
+  echo "✓"
+  PASS=$((PASS+1))
+else
+  echo "✗ FAILED"
+  echo "$VET_OUT" | sed 's/^/    /'
+  FAIL=$((FAIL+1))
+fi
+
+# --- go build ---
+printf "  %-20s" "go build"
+BUILD_OUT=$(go build ./... 2>&1)
+if [[ $? -eq 0 ]]; then
+  echo "✓"
+  PASS=$((PASS+1))
+else
+  echo "✗ FAILED"
+  echo "$BUILD_OUT" | sed 's/^/    /'
+  FAIL=$((FAIL+1))
+fi
+
+echo ""
+if [[ $FAIL -gt 0 ]]; then
+  echo "❌ $FAIL check(s) failed. Fix issues or use --no-verify to skip."
+  exit 1
+else
+  echo "✅ All checks passed ($PASS)"
+fi


### PR DESCRIPTION
## What

Adds a git pre-commit hook matching the pattern recently landed in nightshift and sidecar.

## Changes

- `scripts/pre-commit.sh` — checks gofmt on staged `.go` files, `go vet`, `go build`
- `make install-hooks` — symlinks the hook into `.git/hooks/pre-commit`
- README updated to document `make install-hooks` in the dev section

## How to test

```bash
make install-hooks
# stage a .go file and commit — hook should run
```