### PR TITLE
fix: mobile navbar sidebar hidden behind secondary panel

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1421,3 +1421,8 @@ a.sc-features-grid__item:hover {
   filter: drop-shadow(0 6px 24px rgba(180, 100, 255, 0.7));
   transform: translateY(-2px);
 }
+
+/* Fix mobile navbar sidebar: prevent secondary panel from translating off-screen */
+.navbar-sidebar__items--show-secondary {
+  transform: none !important;
+}


### PR DESCRIPTION
Same fix applied to sidecar's website.

**Bug:** `.navbar-sidebar__items--show-secondary` applies `transform: translateX(-83vw)` which pushes all sidebar content off-screen when custom CSS sets `flex-direction: column` on `.navbar-sidebar__items`.

**Fix:** Override with `transform: none !important` to keep the sidebar visible on mobile.