### PR TITLE
Fix closed_at timestamp on approve and close

### DIFF
--- a/cmd/review.go
+++ b/cmd/review.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/marcus/td/internal/config"
 	"github.com/marcus/td/internal/db"
@@ -369,7 +370,7 @@ Supports bulk operations:
 			// Update issue (atomic update + action log)
 			issue.Status = models.StatusClosed
 			issue.ReviewerSession = sess.ID
-			now := issue.UpdatedAt
+			now := time.Now()
 			issue.ClosedAt = &now
 
 			if err := database.UpdateIssueLogged(issue, sess.ID, models.ActionApprove); err != nil {
@@ -674,7 +675,7 @@ Examples:
 
 			// Update issue (atomic update + action log)
 			issue.Status = models.StatusClosed
-			now := issue.UpdatedAt
+			now := time.Now()
 			issue.ClosedAt = &now
 
 			if err := database.UpdateIssueLogged(issue, sess.ID, models.ActionClose); err != nil {


### PR DESCRIPTION
## Summary

- `approveCmd` and `closeCmd` both set `ClosedAt` to `issue.UpdatedAt` (the stale value from before the current transaction) instead of the current time
- This causes `closed_at` to reflect when the issue was last *modified*, not when it was actually *closed*
- Fix: use `time.Now()` instead of `issue.UpdatedAt` in both commands

## Context

Discovered this when building a time-series dashboard that tracks tasks closed per hour. The `closed_at` timestamps were always backdated to previous `updated_at` values, so tasks approved today would appear as if they were closed days ago.

The spec in `docs/td-serve-spec.md` already documents the correct behavior:
> `POST /v1/issues/{id}/approve` → `closed_at = now`

And `docs/ticket-flow.mmd`:
> Set closed_at timestamp

The CLI implementation just wasn't matching the spec.

## Test plan

- [x] All existing tests pass (`go test ./...` — all green including e2e)
- [ ] Manual: `td approve` an issue → verify `closed_at` matches current time, not old `updated_at`

🤖 Generated with [Claude Code](https://claude.com/claude-code)