### PR TITLE
Add section header when appending to .gitignore

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -72,7 +72,7 @@ func addToGitignore(path string) {
 		return
 	}
 
-	// Append to file
+	// Append to file with a section header
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return
@@ -84,7 +84,7 @@ func addToGitignore(path string) {
 		f.WriteString("\n")
 	}
 
-	f.WriteString(".todos/\n")
+	f.WriteString("\n\n# td\n.todos/\n")
 	fmt.Println("Added .todos/ to .gitignore")
 }
 


### PR DESCRIPTION
## Summary
- `td init` now adds `.todos/` under a `# td` header with spacing instead of blindly appending to the end of `.gitignore`
- Makes it clear where the entry came from and keeps the file organized

## Test plan
- [ ] Run `td init` in a repo with an existing `.gitignore` — verify `.todos/` appears under a `# td` header with blank lines above
- [ ] Run `td init` in a repo with no `.gitignore` — verify file is created with the header
- [ ] Run `td init` in a repo where `.todos/` is already in `.gitignore` — verify no duplicate entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)