### PR TITLE
feat: add release-notes command

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ make fmt
 Releases are automated via GoReleaser. Pushing a version tag triggers GitHub Actions to build binaries and update the Homebrew formula.
 
 ```bash
+# Draft the changelog entry you want to ship
+td release-notes --version v0.2.0
+
 # Create and push an annotated tag (triggers automated release)
 make release VERSION=v0.2.0
 

--- a/cmd/release_notes.go
+++ b/cmd/release_notes.go
@@ -1,0 +1,225 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	gitutil "github.com/marcus/td/internal/git"
+	"github.com/spf13/cobra"
+)
+
+const (
+	releaseNotesSectionFeatures      = "Features"
+	releaseNotesSectionBugFixes      = "Bug Fixes"
+	releaseNotesSectionImprovements  = "Improvements"
+	releaseNotesSectionDocumentation = "Documentation"
+	releaseNotesSectionTesting       = "Testing"
+	releaseNotesSectionOtherChanges  = "Other Changes"
+)
+
+var (
+	conventionalCommitPattern = regexp.MustCompile(`(?i)^(feat(?:ure)?|fix|bugfix|bug|docs?|doc|test(?:s)?|refactor|perf|chore|build|ci|style|revert)(?:\(([^)]+)\))?!?:\s*(.+)$`)
+	releaseNotesSectionOrder  = []string{
+		releaseNotesSectionFeatures,
+		releaseNotesSectionBugFixes,
+		releaseNotesSectionImprovements,
+		releaseNotesSectionDocumentation,
+		releaseNotesSectionTesting,
+		releaseNotesSectionOtherChanges,
+	}
+)
+
+var releaseNotesCmd = &cobra.Command{
+	Use:     "release-notes",
+	Short:   "Draft release notes from git history",
+	GroupID: "system",
+	Args:    cobra.NoArgs,
+	Long: `Draft release notes from git history.
+
+By default, td uses the latest reachable semver tag through HEAD as the
+baseline and prints a markdown section you can review and paste into
+CHANGELOG.md.`,
+	Example: `  td release-notes --version v0.44.0
+  td release-notes --from v0.43.0 --to HEAD --date 2026-04-02`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		baseDir := getBaseDir()
+
+		fromRef, _ := cmd.Flags().GetString("from")
+		toRef, _ := cmd.Flags().GetString("to")
+		versionLabel, _ := cmd.Flags().GetString("version")
+		dateLabel, _ := cmd.Flags().GetString("date")
+
+		if dateLabel == "" {
+			dateLabel = time.Now().Format("2006-01-02")
+		} else if _, err := time.Parse("2006-01-02", dateLabel); err != nil {
+			return fmt.Errorf("invalid --date %q: use YYYY-MM-DD", dateLabel)
+		}
+
+		data, err := gitutil.GetReleaseNotesData(baseDir, gitutil.ReleaseNotesOptions{
+			FromRef: fromRef,
+			ToRef:   toRef,
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, gitutil.ErrNotRepository):
+				return fmt.Errorf("release notes require a git repository")
+			default:
+				return err
+			}
+		}
+
+		_, _ = fmt.Fprint(cmd.OutOrStdout(), formatReleaseNotesMarkdown(data, versionLabel, dateLabel))
+		return nil
+	},
+}
+
+func formatReleaseNotesMarkdown(data *gitutil.ReleaseNotesData, versionLabel, dateLabel string) string {
+	versionLabel = strings.TrimSpace(versionLabel)
+	if versionLabel == "" {
+		versionLabel = "Unreleased"
+	}
+
+	sections := categorizeReleaseNotes(data.Commits)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "## [%s] - %s\n\n", versionLabel, dateLabel)
+
+	for _, section := range releaseNotesSectionOrder {
+		entries := sections[section]
+		if len(entries) == 0 {
+			continue
+		}
+
+		fmt.Fprintf(&b, "### %s\n", section)
+		for _, entry := range entries {
+			fmt.Fprintf(&b, "- %s\n", entry)
+		}
+		b.WriteString("\n")
+	}
+
+	return strings.TrimRight(b.String(), "\n") + "\n"
+}
+
+func categorizeReleaseNotes(commits []gitutil.ReleaseCommit) map[string][]string {
+	sections := make(map[string][]string)
+	for _, commit := range commits {
+		section, entry := releaseNoteEntry(commit)
+		sections[section] = append(sections[section], entry)
+	}
+	return sections
+}
+
+func releaseNoteEntry(commit gitutil.ReleaseCommit) (string, string) {
+	subject := strings.TrimSpace(commit.Subject)
+	if subject == "" {
+		shortSHA := commit.SHA
+		if len(shortSHA) > 7 {
+			shortSHA = shortSHA[:7]
+		}
+		return releaseNotesSectionOtherChanges, fmt.Sprintf("Update in commit %s", shortSHA)
+	}
+
+	if matches := conventionalCommitPattern.FindStringSubmatch(subject); len(matches) == 4 {
+		section := releaseNoteSectionForPrefix(strings.ToLower(matches[1]))
+		scope := strings.TrimSpace(matches[2])
+		description := prettifyReleaseSummary(matches[3])
+		if scope != "" {
+			return section, fmt.Sprintf("%s: %s", scope, description)
+		}
+		return section, description
+	}
+
+	switch {
+	case releaseNotesAreDocumentationFiles(commit.Files):
+		return releaseNotesSectionDocumentation, prettifyReleaseSummary(subject)
+	case releaseNotesAreTestFiles(commit.Files):
+		return releaseNotesSectionTesting, prettifyReleaseSummary(subject)
+	default:
+		return releaseNotesSectionImprovements, prettifyReleaseSummary(subject)
+	}
+}
+
+func releaseNoteSectionForPrefix(prefix string) string {
+	switch prefix {
+	case "feat", "feature":
+		return releaseNotesSectionFeatures
+	case "fix", "bugfix", "bug":
+		return releaseNotesSectionBugFixes
+	case "docs", "doc":
+		return releaseNotesSectionDocumentation
+	case "test", "tests":
+		return releaseNotesSectionTesting
+	case "refactor", "perf", "chore", "build", "ci", "style":
+		return releaseNotesSectionImprovements
+	default:
+		return releaseNotesSectionOtherChanges
+	}
+}
+
+func releaseNotesAreDocumentationFiles(files []string) bool {
+	if len(files) == 0 {
+		return false
+	}
+	for _, file := range files {
+		if !isDocumentationFile(file) {
+			return false
+		}
+	}
+	return true
+}
+
+func releaseNotesAreTestFiles(files []string) bool {
+	if len(files) == 0 {
+		return false
+	}
+	for _, file := range files {
+		if !isTestFile(file) {
+			return false
+		}
+	}
+	return true
+}
+
+func isDocumentationFile(path string) bool {
+	return strings.HasPrefix(path, "docs/") ||
+		strings.HasPrefix(path, "website/docs/") ||
+		strings.HasSuffix(path, ".md") ||
+		path == "README" ||
+		path == "README.md" ||
+		path == "CHANGELOG.md"
+}
+
+func isTestFile(path string) bool {
+	return strings.HasPrefix(path, "test/") ||
+		strings.Contains(path, "/testdata/") ||
+		strings.HasSuffix(path, "_test.go")
+}
+
+func prettifyReleaseSummary(summary string) string {
+	summary = strings.TrimSpace(summary)
+	if summary == "" {
+		return summary
+	}
+
+	r, size := utf8.DecodeRuneInString(summary)
+	if r == utf8.RuneError && size == 0 {
+		return summary
+	}
+	if !unicode.IsLower(r) {
+		return summary
+	}
+	return string(unicode.ToUpper(r)) + summary[size:]
+}
+
+func init() {
+	rootCmd.AddCommand(releaseNotesCmd)
+	releaseNotesCmd.Flags().String("from", "", "Start the range at this git ref or tag")
+	releaseNotesCmd.Flags().String("to", "HEAD", "End the range at this git ref")
+	releaseNotesCmd.Flags().String("version", "", "Version label for the markdown header")
+	releaseNotesCmd.Flags().String("date", "", "Date for the markdown header (YYYY-MM-DD)")
+}

--- a/cmd/release_notes_test.go
+++ b/cmd/release_notes_test.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func initReleaseNotesRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := initGitRepo(t)
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	runGit(t, dir, "config", "user.name", "Test User")
+	commitReleaseNotesFile(t, dir, "README.md", "# Test\n", "chore: initial commit")
+	return dir
+}
+
+func commitReleaseNotesFile(t *testing.T, dir, path, content, message string) {
+	t.Helper()
+
+	fullPath := filepath.Join(dir, path)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	runGit(t, dir, "add", path)
+	runGit(t, dir, "commit", "-m", message)
+}
+
+func tagReleaseNotesRepo(t *testing.T, dir, tag string) {
+	t.Helper()
+	runGit(t, dir, "tag", tag)
+}
+
+func runReleaseNotesCommand(t *testing.T, dir string, flagPairs ...string) (string, error) {
+	t.Helper()
+
+	saveAndRestoreGlobals(t)
+	baseDir := dir
+	baseDirOverride = &baseDir
+
+	_ = releaseNotesCmd.Flags().Set("from", "")
+	_ = releaseNotesCmd.Flags().Set("to", "HEAD")
+	_ = releaseNotesCmd.Flags().Set("version", "")
+	_ = releaseNotesCmd.Flags().Set("date", "")
+
+	for i := 0; i+1 < len(flagPairs); i += 2 {
+		if err := releaseNotesCmd.Flags().Set(flagPairs[i], flagPairs[i+1]); err != nil {
+			t.Fatalf("failed to set --%s: %v", flagPairs[i], err)
+		}
+	}
+
+	var output bytes.Buffer
+	releaseNotesCmd.SetOut(&output)
+
+	err := releaseNotesCmd.RunE(releaseNotesCmd, nil)
+	return output.String(), err
+}
+
+func TestReleaseNotesCommandFormatsStableMarkdown(t *testing.T) {
+	dir := initReleaseNotesRepo(t)
+
+	tagReleaseNotesRepo(t, dir, "v0.1.0")
+	commitReleaseNotesFile(t, dir, "cmd/release_notes.go", "package cmd\n", "feat: add release notes command")
+	commitReleaseNotesFile(t, dir, "internal/git/git.go", "package git\n", "fix: handle empty release range")
+	commitReleaseNotesFile(t, dir, "docs/guides/releasing.md", "# Release\n", "refresh release guide")
+	commitReleaseNotesFile(t, dir, "cmd/release_notes_test.go", "package cmd\n", "test: cover release notes command")
+	commitReleaseNotesFile(t, dir, "internal/git/release.go", "package git\n", "refactor: simplify range parsing")
+
+	output, err := runReleaseNotesCommand(
+		t,
+		dir,
+		"from", "v0.1.0",
+		"to", "HEAD",
+		"version", "v1.2.3",
+		"date", "2026-04-02",
+	)
+	if err != nil {
+		t.Fatalf("releaseNotesCmd.RunE returned error: %v", err)
+	}
+
+	expected := `## [v1.2.3] - 2026-04-02
+
+### Features
+- Add release notes command
+
+### Bug Fixes
+- Handle empty release range
+
+### Improvements
+- Simplify range parsing
+
+### Documentation
+- Refresh release guide
+
+### Testing
+- Cover release notes command
+`
+
+	if output != expected {
+		t.Fatalf("unexpected markdown output:\n%s", output)
+	}
+}
+
+func TestReleaseNotesCommandDefaultsToLatestTag(t *testing.T) {
+	dir := initReleaseNotesRepo(t)
+
+	tagReleaseNotesRepo(t, dir, "v0.1.0")
+	commitReleaseNotesFile(t, dir, "feature.txt", "feature\n", "feat: add old feature")
+	tagReleaseNotesRepo(t, dir, "v0.2.0")
+	commitReleaseNotesFile(t, dir, "fix.txt", "fix\n", "fix: patch release")
+
+	output, err := runReleaseNotesCommand(
+		t,
+		dir,
+		"version", "v0.2.1",
+		"date", "2026-04-02",
+	)
+	if err != nil {
+		t.Fatalf("releaseNotesCmd.RunE returned error: %v", err)
+	}
+
+	if strings.Contains(output, "Add old feature") {
+		t.Fatalf("expected output to use latest tag only, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Patch release") {
+		t.Fatalf("expected output to include latest fix, got:\n%s", output)
+	}
+}
+
+func TestReleaseNotesCommandReturnsErrorForEmptyRange(t *testing.T) {
+	dir := initReleaseNotesRepo(t)
+	tagReleaseNotesRepo(t, dir, "v0.1.0")
+
+	_, err := runReleaseNotesCommand(t, dir, "date", "2026-04-02")
+	if err == nil {
+		t.Fatal("expected empty range error")
+	}
+	if !strings.Contains(err.Error(), "no commits found in range v0.1.0..HEAD") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/docs/guides/releasing-new-version.md
+++ b/docs/guides/releasing-new-version.md
@@ -8,7 +8,7 @@ Releases are automated via [GoReleaser](https://goreleaser.com/) and GitHub Acti
 
 1. Builds binaries for darwin/linux × amd64/arm64
 2. Creates a GitHub release with binary assets and checksums
-3. Generates a changelog from commits since the last tag
+3. Generates GitHub release notes from commits since the last tag
 4. Pushes a Homebrew tap formula (`Casks/td.rb`) to `marcus/homebrew-tap`
 
 ## Prerequisites
@@ -33,9 +33,15 @@ Check current version:
 git tag -l | sort -V | tail -1
 ```
 
-### 2. Update CHANGELOG.md
+### 2. Draft and Update CHANGELOG.md
 
-Add entry at the top of `CHANGELOG.md`:
+Generate a draft from git history:
+
+```bash
+td release-notes --version vX.Y.Z
+```
+
+Review the output, edit as needed, then paste the entry at the top of `CHANGELOG.md`:
 
 ```markdown
 ## [vX.Y.Z] - YYYY-MM-DD
@@ -134,8 +140,9 @@ Replace `X.Y.Z` with actual version:
 git status
 go test ./...
 
-# Update changelog
-# (Edit CHANGELOG.md, add entry at top)
+# Draft release notes and update changelog
+td release-notes --version vX.Y.Z
+# (Review/edit the draft, then paste it into CHANGELOG.md)
 git add CHANGELOG.md
 git commit -m "docs: Update changelog for vX.Y.Z"
 
@@ -154,6 +161,7 @@ brew upgrade td && td version
 
 - [ ] Tests pass (`go test ./...`)
 - [ ] Working tree clean
+- [ ] `td release-notes --version vX.Y.Z` reviewed and edited
 - [ ] CHANGELOG.md updated with new version entry
 - [ ] Changelog committed to git
 - [ ] Version number follows semver

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -4,10 +4,24 @@ package git
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os/exec"
+	"regexp"
+	"sort"
 	"strconv"
 	"strings"
+)
+
+var (
+	// ErrNotRepository indicates the target directory is not inside a git repo.
+	ErrNotRepository = errors.New("not a git repository")
+	// ErrNoSemverTag indicates no reachable semver tag was found for the range.
+	ErrNoSemverTag = errors.New("no reachable semver tag found")
+	// ErrNoCommits indicates a range resolved successfully but contained no commits.
+	ErrNoCommits = errors.New("no commits found")
+
+	semverTagPattern = regexp.MustCompile(`^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$`)
 )
 
 // State represents the current git state
@@ -91,6 +105,29 @@ type FileChange struct {
 	Additions int
 	Deletions int
 	IsNew     bool
+}
+
+// ReleaseNotesOptions controls how release notes are generated from git history.
+type ReleaseNotesOptions struct {
+	FromRef string
+	ToRef   string
+}
+
+// ReleaseCommit captures a commit subject plus the files it touched.
+type ReleaseCommit struct {
+	SHA     string
+	Subject string
+	Files   []string
+}
+
+// ReleaseNotesData describes a resolved release-note range and its commits.
+type ReleaseNotesData struct {
+	RepoRoot    string
+	FromRef     string
+	ToRef       string
+	BaselineTag string
+	Commits     []ReleaseCommit
+	Files       []string
 }
 
 func parseStatOutput(output string) []FileChange {
@@ -179,21 +216,199 @@ func GetDiffStatsSince(sha string) (*DiffStats, error) {
 
 // IsRepo checks if we're in a git repository
 func IsRepo() bool {
-	_, err := runGit("rev-parse", "--git-dir")
-	return err == nil
+	return IsRepoAt("")
 }
 
 // GetRootDir returns the git repository root directory
 func GetRootDir() (string, error) {
-	output, err := runGit("rev-parse", "--show-toplevel")
+	return GetRootDirFrom("")
+}
+
+// IsRepoAt checks whether dir is inside a git repository.
+func IsRepoAt(dir string) bool {
+	_, err := runGitInDir(dir, "rev-parse", "--git-dir")
+	return err == nil
+}
+
+// GetRootDirFrom returns the git repository root for dir.
+func GetRootDirFrom(dir string) (string, error) {
+	output, err := runGitInDir(dir, "rev-parse", "--show-toplevel")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("%w", ErrNotRepository)
 	}
 	return strings.TrimSpace(output), nil
 }
 
+// GetLatestSemverTag returns the latest reachable semver tag for ref.
+func GetLatestSemverTag(dir, ref string) (string, error) {
+	root, err := GetRootDirFrom(dir)
+	if err != nil {
+		return "", err
+	}
+
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		ref = "HEAD"
+	}
+
+	if err := verifyCommitRef(root, ref); err != nil {
+		return "", err
+	}
+
+	output, err := runGitInDir(root, "tag", "--merged", ref, "--sort=-version:refname")
+	if err != nil {
+		return "", err
+	}
+
+	for _, line := range strings.Split(output, "\n") {
+		tag := strings.TrimSpace(line)
+		if tag == "" {
+			continue
+		}
+		if semverTagPattern.MatchString(tag) {
+			return tag, nil
+		}
+	}
+
+	return "", fmt.Errorf("%w from %s; use --from to specify a range", ErrNoSemverTag, ref)
+}
+
+// GetReleaseNotesData resolves a git range and returns commits and changed files
+// for drafting release notes.
+func GetReleaseNotesData(dir string, opts ReleaseNotesOptions) (*ReleaseNotesData, error) {
+	root, err := GetRootDirFrom(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	toRef := strings.TrimSpace(opts.ToRef)
+	if toRef == "" {
+		toRef = "HEAD"
+	}
+	if err := verifyCommitRef(root, toRef); err != nil {
+		return nil, err
+	}
+
+	fromRef := strings.TrimSpace(opts.FromRef)
+	baselineTag := ""
+	if fromRef == "" {
+		baselineTag, err = GetLatestSemverTag(root, toRef)
+		if err != nil {
+			return nil, err
+		}
+		fromRef = baselineTag
+	} else if err := verifyCommitRef(root, fromRef); err != nil {
+		return nil, err
+	}
+
+	commits, err := listReleaseCommits(root, fromRef, toRef)
+	if err != nil {
+		return nil, err
+	}
+
+	files, err := listChangedFiles(root, fromRef, toRef)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ReleaseNotesData{
+		RepoRoot:    root,
+		FromRef:     fromRef,
+		ToRef:       toRef,
+		BaselineTag: baselineTag,
+		Commits:     commits,
+		Files:       files,
+	}, nil
+}
+
+func verifyCommitRef(dir, ref string) error {
+	if _, err := runGitInDir(dir, "rev-parse", "--verify", ref+"^{commit}"); err != nil {
+		return fmt.Errorf("invalid git ref %q: %w", ref, err)
+	}
+	return nil
+}
+
+func listReleaseCommits(dir, fromRef, toRef string) ([]ReleaseCommit, error) {
+	output, err := runGitInDir(dir, "log", "--no-merges", "--reverse", "--format=%H%x00%s", fromRef+".."+toRef)
+	if err != nil {
+		return nil, err
+	}
+
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return nil, fmt.Errorf("%w in range %s..%s", ErrNoCommits, fromRef, toRef)
+	}
+
+	lines := strings.Split(output, "\n")
+	commits := make([]ReleaseCommit, 0, len(lines))
+	for _, line := range lines {
+		parts := strings.SplitN(line, "\x00", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		files, err := listFilesForCommit(dir, strings.TrimSpace(parts[0]))
+		if err != nil {
+			return nil, err
+		}
+
+		commits = append(commits, ReleaseCommit{
+			SHA:     strings.TrimSpace(parts[0]),
+			Subject: strings.TrimSpace(parts[1]),
+			Files:   files,
+		})
+	}
+
+	if len(commits) == 0 {
+		return nil, fmt.Errorf("%w in range %s..%s", ErrNoCommits, fromRef, toRef)
+	}
+
+	return commits, nil
+}
+
+func listFilesForCommit(dir, sha string) ([]string, error) {
+	output, err := runGitInDir(dir, "show", "--pretty=format:", "--name-only", "--diff-filter=ACDMRT", sha)
+	if err != nil {
+		return nil, err
+	}
+	return splitUniqueLines(output), nil
+}
+
+func listChangedFiles(dir, fromRef, toRef string) ([]string, error) {
+	output, err := runGitInDir(dir, "diff", "--name-only", fromRef+".."+toRef)
+	if err != nil {
+		return nil, err
+	}
+	return splitUniqueLines(output), nil
+}
+
+func splitUniqueLines(output string) []string {
+	seen := make(map[string]struct{})
+	var lines []string
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if _, ok := seen[line]; ok {
+			continue
+		}
+		seen[line] = struct{}{}
+		lines = append(lines, line)
+	}
+	sort.Strings(lines)
+	return lines
+}
+
 func runGit(args ...string) (string, error) {
+	return runGitInDir("", args...)
+}
+
+func runGitInDir(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,9 +1,11 @@
 package git
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -43,6 +45,44 @@ func runCmd(dir string, name string, args ...string) error {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	return cmd.Run()
+}
+
+func runCmdOutput(dir string, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func commitFile(t *testing.T, dir, path, content, message string) string {
+	t.Helper()
+
+	fullPath := filepath.Join(dir, path)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+		t.Fatalf("Failed to create parent dir: %v", err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	if err := runCmd(dir, "git", "add", path); err != nil {
+		t.Fatalf("Failed to git add %s: %v", path, err)
+	}
+	if err := runCmd(dir, "git", "commit", "-m", message); err != nil {
+		t.Fatalf("Failed to commit %q: %v", message, err)
+	}
+
+	sha, err := runCmdOutput(dir, "git", "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("Failed to get HEAD sha: %v", err)
+	}
+	return sha
+}
+
+func tagHead(t *testing.T, dir, tag string) {
+	t.Helper()
+	if err := runCmd(dir, "git", "tag", tag); err != nil {
+		t.Fatalf("Failed to create tag %s: %v", tag, err)
+	}
 }
 
 // TestParseStatOutputBasic tests parsing git diff --stat output
@@ -467,5 +507,84 @@ func TestStateBranchName(t *testing.T) {
 	// The branch should be either 'main', 'master', or some default
 	if state.Branch != "main" && state.Branch != "master" && state.Branch != "HEAD" {
 		t.Logf("Branch name is %q (expected main/master/HEAD)", state.Branch)
+	}
+}
+
+func TestGetLatestSemverTag(t *testing.T) {
+	dir := initTestRepo(t)
+
+	tagHead(t, dir, "v0.1.0")
+	commitFile(t, dir, "feature.txt", "feature\n", "feat: add feature")
+	tagHead(t, dir, "v0.2.0")
+	commitFile(t, dir, "fix.txt", "fix\n", "fix: patch release")
+
+	tag, err := GetLatestSemverTag(dir, "HEAD")
+	if err != nil {
+		t.Fatalf("GetLatestSemverTag failed: %v", err)
+	}
+	if tag != "v0.2.0" {
+		t.Fatalf("tag = %q, want %q", tag, "v0.2.0")
+	}
+}
+
+func TestGetReleaseNotesDataExplicitRange(t *testing.T) {
+	dir := initTestRepo(t)
+
+	tagHead(t, dir, "v0.1.0")
+	commitFile(t, dir, "docs/guide.md", "# Guide\n", "docs: add guide")
+	midSHA := commitFile(t, dir, "cmd/release_notes.go", "package cmd\n", "feat: add command")
+	commitFile(t, dir, "cmd/release_notes_test.go", "package cmd\n", "test: add command coverage")
+
+	data, err := GetReleaseNotesData(dir, ReleaseNotesOptions{FromRef: midSHA + "^", ToRef: "HEAD"})
+	if err != nil {
+		t.Fatalf("GetReleaseNotesData failed: %v", err)
+	}
+
+	if data.BaselineTag != "" {
+		t.Fatalf("BaselineTag = %q, want empty for explicit range", data.BaselineTag)
+	}
+	if data.FromRef != midSHA+"^" {
+		t.Fatalf("FromRef = %q, want %q", data.FromRef, midSHA+"^")
+	}
+	if len(data.Commits) != 2 {
+		t.Fatalf("expected 2 commits, got %d", len(data.Commits))
+	}
+	if data.Commits[0].Subject != "feat: add command" {
+		t.Fatalf("first subject = %q", data.Commits[0].Subject)
+	}
+	if data.Commits[1].Subject != "test: add command coverage" {
+		t.Fatalf("second subject = %q", data.Commits[1].Subject)
+	}
+	if len(data.Files) != 2 {
+		t.Fatalf("expected 2 changed files, got %d (%v)", len(data.Files), data.Files)
+	}
+}
+
+func TestGetReleaseNotesDataNoTag(t *testing.T) {
+	dir := initTestRepo(t)
+	commitFile(t, dir, "feature.txt", "feature\n", "feat: add feature")
+
+	_, err := GetReleaseNotesData(dir, ReleaseNotesOptions{})
+	if !errors.Is(err, ErrNoSemverTag) {
+		t.Fatalf("expected ErrNoSemverTag, got %v", err)
+	}
+}
+
+func TestGetReleaseNotesDataNoCommits(t *testing.T) {
+	dir := initTestRepo(t)
+	tagHead(t, dir, "v0.1.0")
+
+	_, err := GetReleaseNotesData(dir, ReleaseNotesOptions{})
+	if !errors.Is(err, ErrNoCommits) {
+		t.Fatalf("expected ErrNoCommits, got %v", err)
+	}
+}
+
+func TestGetReleaseNotesDataNotRepo(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := GetReleaseNotesData(dir, ReleaseNotesOptions{})
+	if !errors.Is(err, ErrNotRepository) {
+		t.Fatalf("expected ErrNotRepository, got %v", err)
 	}
 }

--- a/website/docs/command-reference.md
+++ b/website/docs/command-reference.md
@@ -142,6 +142,7 @@ cat docs/acceptance.md | td update td-a1b2 --append --acceptance-file -
 | `td monitor` | Live TUI dashboard |
 | `td undo` | Undo last action |
 | `td version` | Show version |
+| `td release-notes [flags]` | Draft markdown release notes from git history. Flags: `--from`, `--to`, `--version`, `--date` |
 | `td export` | Export database |
 | `td import` | Import issues |
 | `td stats [subcommand]` | Usage statistics |


### PR DESCRIPTION
## Summary
- add a local-first \ command that drafts markdown notes from git history
- extend \ with latest-tag/range resolution, structured release-note commit data, and focused temp-repo tests
- document the new release workflow in the release guide, README, and website command reference

## Testing
- go test ./internal/git ./cmd
- go run . release-notes --version vNEXT --date 2026-04-02


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: release-notes:/Users/marcus/code/td
task-type: release-notes
task-title: Release Note Drafter
provider: codex
score: 0.7
cost-tier: Low (10-50k)
branch: main
iterations: 1
duration: 23m30s
run-started: 2026-04-02T02:25:16-07:00
nightshift:metadata -->
