### PR TITLE
feat: add -p shorthand for --priority in update command

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -260,7 +260,7 @@ func init() {
 	updateCmd.Flags().String("acceptance", "", "New acceptance criteria")
 	updateCmd.Flags().String("acceptance-file", "", "Read acceptance criteria from file or - for stdin (preserves formatting)")
 	updateCmd.Flags().String("type", "", "New type")
-	updateCmd.Flags().String("priority", "", "New priority")
+	updateCmd.Flags().StringP("priority", "p", "", "New priority (P0, P1, P2, P3, P4)")
 	updateCmd.Flags().Int("points", 0, "New story points")
 	updateCmd.Flags().StringArrayP("labels", "l", nil, "Replace labels (repeatable, comma-separated)")
 	updateCmd.Flags().String("sprint", "", "New sprint name (empty string to clear)")


### PR DESCRIPTION
`td create` supports `-p` as a shorthand for `--priority` (via `StringP`), but `td update` only registers the long form (`String`). Since `-p` is unused in the update command, there is no conflict.

This change:
- Switches `update.go` flag registration from `String` to `StringP` with `"p"` shorthand
- Also aligns the help text to list valid values (`P0, P1, P2, P3, P4`), matching `create`