### PR TITLE
Add --json flag to next command

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -470,6 +470,13 @@ var nextCmd = &cobra.Command{
 			return err
 		}
 
+		if jsonOutput, _ := cmd.Flags().GetBool("json"); jsonOutput {
+			if len(result.issues) == 0 {
+				return output.JSON(nil)
+			}
+			return output.JSON(result.issues[0])
+		}
+
 		if len(result.issues) == 0 {
 			fmt.Println("No open issues")
 			return nil
@@ -762,6 +769,7 @@ func init() {
 	listCmd.Flags().BoolP("all", "a", false, "Include closed and deferred issues")
 
 	deletedCmd.Flags().Bool("json", false, "JSON output")
+	nextCmd.Flags().Bool("json", false, "JSON output")
 
 	listCmd.Flags().Bool("deferred", false, "Show only currently deferred tasks")
 	listCmd.Flags().Bool("overdue", false, "Show tasks past their due date")


### PR DESCRIPTION
Adds `--json` flag support to `td next` so machine consumers can parse structured output.

**Behavior:**
- `td next` — unchanged (human-readable)
- `td next --json` with a task — outputs single JSON object
- `td next --json` with no tasks — outputs `null`, exit 0

Uses the same pattern as `deletedCmd` for JSON output via `output.JSON()`.