### PR TITLE
feat: add panel zoom toggle (z key) in monitor mode

### DIFF
--- a/pkg/monitor/commands.go
+++ b/pkg/monitor/commands.go
@@ -1507,6 +1507,15 @@ func (m Model) executeCommand(cmd keymap.Command) (tea.Model, tea.Cmd) {
 		m.KanbanFullscreen = !m.KanbanFullscreen
 		return m, nil
 
+	case keymap.CmdTogglePanelZoom:
+		if m.PanelZoomed && m.ZoomedPanel == m.ActivePanel {
+			m.PanelZoomed = false
+		} else {
+			m.PanelZoomed = true
+			m.ZoomedPanel = m.ActivePanel
+		}
+		return m, nil
+
 	// Getting started commands
 	case keymap.CmdOpenGettingStarted:
 		return m.openGettingStarted()

--- a/pkg/monitor/input.go
+++ b/pkg/monitor/input.go
@@ -788,13 +788,22 @@ func (m *Model) updatePanelBounds() {
 	availableHeight := m.Height - footerHeight - searchBarHeight
 
 	// Calculate panel heights from ratios
-	panelHeights := [3]int{
-		int(float64(availableHeight) * m.PaneHeights[0]),
-		int(float64(availableHeight) * m.PaneHeights[1]),
-		int(float64(availableHeight) * m.PaneHeights[2]),
+	var panelHeights [3]int
+	if m.PanelZoomed {
+		for i := range panelHeights {
+			if Panel(i) == m.ZoomedPanel {
+				panelHeights[i] = availableHeight
+			}
+		}
+	} else {
+		panelHeights = [3]int{
+			int(float64(availableHeight) * m.PaneHeights[0]),
+			int(float64(availableHeight) * m.PaneHeights[1]),
+			int(float64(availableHeight) * m.PaneHeights[2]),
+		}
+		// Adjust last panel to absorb rounding errors
+		panelHeights[2] = availableHeight - panelHeights[0] - panelHeights[1]
 	}
-	// Adjust last panel to absorb rounding errors
-	panelHeights[2] = availableHeight - panelHeights[0] - panelHeights[1]
 
 	// Calculate Y positions for each panel (stacked vertically)
 	// Order: search bar (optional) → Current Work → Task List → Activity → footer

--- a/pkg/monitor/input.go
+++ b/pkg/monitor/input.go
@@ -1563,4 +1563,3 @@ func (m Model) handleFormDialogHover(x, y int) (tea.Model, tea.Cmd) {
 
 	return m, nil
 }
-

--- a/pkg/monitor/keymap/bindings.go
+++ b/pkg/monitor/keymap/bindings.go
@@ -411,6 +411,10 @@ func DefaultBindings() []Binding {
 		{Key: "up", Command: CmdCursorUp, Context: ContextKanban, Description: "Move up in column"},
 		{Key: "enter", Command: CmdOpenDetails, Context: ContextKanban, Description: "Open issue details"},
 		{Key: "f", Command: CmdToggleKanbanFullscreen, Context: ContextKanban, Description: "Toggle fullscreen"},
+
+		// Panel zoom
+		{Key: "z", Command: CmdTogglePanelZoom, Context: ContextMain, Description: "Toggle panel zoom"},
+		{Key: "z", Command: CmdTogglePanelZoom, Context: ContextBoard, Description: "Toggle panel zoom"},
 	}
 }
 

--- a/pkg/monitor/keymap/export.go
+++ b/pkg/monitor/keymap/export.go
@@ -127,6 +127,7 @@ var commandMetadata = map[Command]struct {
 	CmdOpenKanban:             {"Kanban", "Open kanban view", 2},
 	CmdCloseKanban:            {"Close", "Close kanban view", 3},
 	CmdToggleKanbanFullscreen: {"Fullscreen", "Toggle fullscreen kanban", 2},
+	CmdTogglePanelZoom:        {"Zoom", "Toggle panel zoom", 1},
 }
 
 // ExportBindings returns all bindings in a format sidecar can consume.

--- a/pkg/monitor/keymap/help.go
+++ b/pkg/monitor/keymap/help.go
@@ -299,13 +299,13 @@ func (r *Registry) GenerateTDQHelp() string {
 // FooterHelp generates a compact help string for the footer
 func (r *Registry) FooterHelp() string {
 	// Grouped: actions | view controls | search/nav
-	return "n:new e:edit x:del a:approve r:review  S:sort T:type c:closed b:boards  /:search s:stats tab:panel ?:help"
+	return "n:new e:edit x:del a:approve r:review  S:sort T:type c:closed b:boards  /:search s:stats z:zoom tab:panel ?:help"
 }
 
 // BoardFooterHelp generates help text for board mode footer
 func (r *Registry) BoardFooterHelp() string {
 	// Board-specific: v:view toggles swimlanes/backlog, F:filter cycles status
-	return "n:new e:edit x:del a:approve  v:view S:sort T:type F:filter c:closed b:boards  /:search s:stats tab:panel ?:help"
+	return "n:new e:edit x:del a:approve  v:view S:sort T:type F:filter c:closed b:boards  /:search s:stats z:zoom tab:panel ?:help"
 }
 
 // ModalFooterHelp generates help text for the modal footer

--- a/pkg/monitor/keymap/registry.go
+++ b/pkg/monitor/keymap/registry.go
@@ -157,6 +157,7 @@ const (
 	CmdOpenKanban            Command = "open-kanban"
 	CmdCloseKanban           Command = "close-kanban"
 	CmdToggleKanbanFullscreen Command = "toggle-kanban-fullscreen"
+	CmdTogglePanelZoom        Command = "toggle-panel-zoom"
 )
 
 // Binding maps a key or key sequence to a command in a specific context

--- a/pkg/monitor/keymap/registry.go
+++ b/pkg/monitor/keymap/registry.go
@@ -29,13 +29,13 @@ const (
 	ContextHelp              Context = "help"                // When help modal is open
 	ContextBoardPicker       Context = "board-picker"        // When board picker is open
 	ContextBoard             Context = "board"               // When board mode is active
-	ContextGettingStarted    Context = "getting-started"    // When getting started modal is open
-	ContextTDQHelp           Context = "tdq-help"           // When TDQ help modal is open
-	ContextBoardEditor       Context = "board-editor"       // When board edit/create modal is open
-	ContextCloseConfirm      Context = "close-confirm"      // When close confirmation modal is open (has text input)
-	ContextSyncPrompt        Context = "td-sync-prompt"    // When sync prompt modal is open
-	ContextKanban            Context = "kanban"            // When kanban view modal is open
-	ContextNotes             Context = "notes"             // When notes modal is open
+	ContextGettingStarted    Context = "getting-started"     // When getting started modal is open
+	ContextTDQHelp           Context = "tdq-help"            // When TDQ help modal is open
+	ContextBoardEditor       Context = "board-editor"        // When board edit/create modal is open
+	ContextCloseConfirm      Context = "close-confirm"       // When close confirmation modal is open (has text input)
+	ContextSyncPrompt        Context = "td-sync-prompt"      // When sync prompt modal is open
+	ContextKanban            Context = "kanban"              // When kanban view modal is open
+	ContextNotes             Context = "notes"               // When notes modal is open
 )
 
 // Command represents a named command that can be triggered by key bindings
@@ -52,32 +52,32 @@ const (
 	CmdNextPanel    Command = "next-panel"
 	CmdPrevPanel    Command = "prev-panel"
 	CmdCursorDown   Command = "cursor-down"
-	CmdCursorUp      Command = "cursor-up"
-	CmdCursorTop     Command = "cursor-top"
-	CmdCursorBottom  Command = "cursor-bottom"
-	CmdHalfPageDown  Command = "half-page-down"
-	CmdHalfPageUp    Command = "half-page-up"
-	CmdFullPageDown  Command = "full-page-down"
-	CmdFullPageUp    Command = "full-page-up"
-	CmdScrollDown    Command = "scroll-down"
-	CmdScrollUp      Command = "scroll-up"
-	CmdSelect        Command = "select"
-	CmdBack          Command = "back"
-	CmdClose         Command = "close"
-	CmdNavigatePrev  Command = "navigate-prev"
-	CmdNavigateNext  Command = "navigate-next"
+	CmdCursorUp     Command = "cursor-up"
+	CmdCursorTop    Command = "cursor-top"
+	CmdCursorBottom Command = "cursor-bottom"
+	CmdHalfPageDown Command = "half-page-down"
+	CmdHalfPageUp   Command = "half-page-up"
+	CmdFullPageDown Command = "full-page-down"
+	CmdFullPageUp   Command = "full-page-up"
+	CmdScrollDown   Command = "scroll-down"
+	CmdScrollUp     Command = "scroll-up"
+	CmdSelect       Command = "select"
+	CmdBack         Command = "back"
+	CmdClose        Command = "close"
+	CmdNavigatePrev Command = "navigate-prev"
+	CmdNavigateNext Command = "navigate-next"
 
 	// Action commands
-	CmdOpenDetails    Command = "open-details"
-	CmdOpenStats      Command = "open-stats"
-	CmdSearch         Command = "search"
-	CmdToggleClosed   Command = "toggle-closed"
-	CmdMarkForReview  Command = "mark-for-review"
-	CmdApprove        Command = "approve"
-	CmdDelete         Command = "delete"
-	CmdConfirm        Command = "confirm"
-	CmdCancel         Command = "cancel"
-	CmdCycleSortMode  Command = "cycle-sort-mode"
+	CmdOpenDetails   Command = "open-details"
+	CmdOpenStats     Command = "open-stats"
+	CmdSearch        Command = "search"
+	CmdToggleClosed  Command = "toggle-closed"
+	CmdMarkForReview Command = "mark-for-review"
+	CmdApprove       Command = "approve"
+	CmdDelete        Command = "delete"
+	CmdConfirm       Command = "confirm"
+	CmdCancel        Command = "cancel"
+	CmdCycleSortMode Command = "cycle-sort-mode"
 
 	// Search-specific commands
 	CmdSearchConfirm   Command = "search-confirm"
@@ -143,19 +143,19 @@ const (
 	CmdSendToWorktree Command = "send-to-worktree"
 
 	// Board editor commands
-	CmdEditBoard          Command = "edit-board"
-	CmdNewBoard           Command = "new-board"
-	CmdBoardEditorSave    Command = "board-editor-save"
-	CmdBoardEditorCancel  Command = "board-editor-cancel"
-	CmdBoardEditorDelete  Command = "board-editor-delete"
+	CmdEditBoard         Command = "edit-board"
+	CmdNewBoard          Command = "new-board"
+	CmdBoardEditorSave   Command = "board-editor-save"
+	CmdBoardEditorCancel Command = "board-editor-cancel"
+	CmdBoardEditorDelete Command = "board-editor-delete"
 
 	// Getting started commands
 	CmdOpenGettingStarted  Command = "open-getting-started"
 	CmdInstallInstructions Command = "install-instructions"
 
 	// Kanban view commands
-	CmdOpenKanban            Command = "open-kanban"
-	CmdCloseKanban           Command = "close-kanban"
+	CmdOpenKanban             Command = "open-kanban"
+	CmdCloseKanban            Command = "close-kanban"
 	CmdToggleKanbanFullscreen Command = "toggle-kanban-fullscreen"
 	CmdTogglePanelZoom        Command = "toggle-panel-zoom"
 )

--- a/pkg/monitor/keymap/registry_test.go
+++ b/pkg/monitor/keymap/registry_test.go
@@ -109,7 +109,7 @@ func TestLookup(t *testing.T) {
 		},
 		{
 			name:    "unknown key returns not found",
-			key:     tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'z'}},
+			key:     tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'9'}},
 			context: ContextMain,
 			want:    "",
 			found:   false,

--- a/pkg/monitor/model.go
+++ b/pkg/monitor/model.go
@@ -116,7 +116,7 @@ type Model struct {
 
 	// Activity detail modal state
 	ActivityDetailOpen         bool
-	ActivityDetailItem         *ActivityItem  // The selected activity item
+	ActivityDetailItem         *ActivityItem // The selected activity item
 	ActivityDetailScroll       int
 	ActivityDetailModal        *modal.Modal   // Declarative modal instance
 	ActivityDetailMouseHandler *mouse.Handler // Mouse handler for activity detail modal
@@ -128,8 +128,8 @@ type Model struct {
 	NotesMouseHandler *mouse.Handler // Mouse handler for notes modal
 
 	// Form modal state
-	FormOpen        bool
-	FormState       *FormState
+	FormOpen         bool
+	FormState        *FormState
 	FormScrollOffset int // Scroll offset for form modal when content overflows
 
 	// Getting Started modal state
@@ -169,14 +169,14 @@ type Model struct {
 	BoardEditorDeleteConfirm bool                    // Whether delete confirmation is active
 
 	// Kanban view state
-	KanbanOpen       bool  // Whether kanban modal overlay is open
-	KanbanCol        int   // Currently selected column (0-based)
-	KanbanRow        int   // Currently selected row within the column (0-based)
-	KanbanFullscreen bool  // Whether kanban view fills the entire viewport
+	KanbanOpen       bool // Whether kanban modal overlay is open
+	KanbanCol        int  // Currently selected column (0-based)
+	KanbanRow        int  // Currently selected row within the column (0-based)
+	KanbanFullscreen bool // Whether kanban view fills the entire viewport
 
 	// Panel zoom state
-	ZoomedPanel Panel // Which panel is zoomed (-1 = none)
-	PanelZoomed bool  // Whether any panel is currently zoomed
+	ZoomedPanel      Panel // Which panel is zoomed (-1 = none)
+	PanelZoomed      bool  // Whether any panel is currently zoomed
 	KanbanColScrolls []int // Per-column scroll offsets (one per kanbanColumnOrder entry)
 
 	// Board mode state

--- a/pkg/monitor/model.go
+++ b/pkg/monitor/model.go
@@ -173,6 +173,10 @@ type Model struct {
 	KanbanCol        int   // Currently selected column (0-based)
 	KanbanRow        int   // Currently selected row within the column (0-based)
 	KanbanFullscreen bool  // Whether kanban view fills the entire viewport
+
+	// Panel zoom state
+	ZoomedPanel Panel // Which panel is zoomed (-1 = none)
+	PanelZoomed bool  // Whether any panel is currently zoomed
 	KanbanColScrolls []int // Per-column scroll offsets (one per kanbanColumnOrder entry)
 
 	// Board mode state

--- a/pkg/monitor/view.go
+++ b/pkg/monitor/view.go
@@ -142,25 +142,38 @@ func (m Model) renderBaseView() string {
 	availableHeight := m.Height - footerHeight - searchBarHeight
 
 	// Calculate individual panel heights from ratios
-	panelHeights := [3]int{
-		int(float64(availableHeight) * m.PaneHeights[0]),
-		int(float64(availableHeight) * m.PaneHeights[1]),
-		int(float64(availableHeight) * m.PaneHeights[2]),
+	var panelHeights [3]int
+	if m.PanelZoomed {
+		// Zoomed panel gets all available height, others get 0
+		for i := range panelHeights {
+			if Panel(i) == m.ZoomedPanel {
+				panelHeights[i] = availableHeight
+			}
+		}
+	} else {
+		panelHeights = [3]int{
+			int(float64(availableHeight) * m.PaneHeights[0]),
+			int(float64(availableHeight) * m.PaneHeights[1]),
+			int(float64(availableHeight) * m.PaneHeights[2]),
+		}
+		// Adjust last panel to absorb rounding errors
+		panelHeights[2] = availableHeight - panelHeights[0] - panelHeights[1]
 	}
-	// Adjust last panel to absorb rounding errors
-	panelHeights[2] = availableHeight - panelHeights[0] - panelHeights[1]
 
-	// Render each panel with its specific height
-	currentWork := m.renderCurrentWorkPanel(panelHeights[0])
-	activity := m.renderActivityPanel(panelHeights[2])
-	taskList := m.renderTaskListPanel(panelHeights[1])
+	// Render each panel with its specific height (skip panels with 0 height)
+	var panelParts []string
+	if panelHeights[0] > 0 {
+		panelParts = append(panelParts, m.renderCurrentWorkPanel(panelHeights[0]))
+	}
+	if panelHeights[1] > 0 {
+		panelParts = append(panelParts, m.renderTaskListPanel(panelHeights[1]))
+	}
+	if panelHeights[2] > 0 {
+		panelParts = append(panelParts, m.renderActivityPanel(panelHeights[2]))
+	}
 
 	// Stack panels vertically (Current Work → Task List → Activity)
-	panels := lipgloss.JoinVertical(lipgloss.Left,
-		currentWork,
-		taskList,
-		activity,
-	)
+	panels := lipgloss.JoinVertical(lipgloss.Left, panelParts...)
 
 	// Add search bar if present
 	var content string


### PR DESCRIPTION
## Summary

- motivation: I'm finding it hard to manage a backlog while seeing only ~10 items at a time. 

- Adds a `z` keybinding that zooms the active panel to full screen height, hiding the other two panels. Press `z` again to restore the original layout.
- Works in both main and board contexts (so backlog view can be zoomed too).
- Follows the existing fullscreen toggle pattern used by the kanban view.

## Changes

- `model.go`: Added `ZoomedPanel` and `PanelZoomed` state fields
- `keymap/`: New `CmdTogglePanelZoom` command bound to `z` in `ContextMain` and `ContextBoard`
- `view.go`: Zoomed panel gets 100% of available height; non-zoomed panels are skipped
- `input.go`: Same zoom-aware height calculation for mouse hit-testing
- `keymap/help.go`: Added `z:zoom` to footer help strings

## Test plan

- [x] `make fmt` — clean (note: found pre-existing gofmt issues in several files across the repo; the second commit includes only the fmt fixes for our changed files)
- [x] `make test` — all tests pass except `TestUndoRestore_ReDeletePropagates` in `test/syncharness` which is a pre-existing failure unrelated to this change
- [x] Manual testing: zoom/unzoom works on all three panels (Current Work, Task List/Backlog, Activity)
- [x] Verified backlog view in board mode zooms correctly (required `ContextBoard` binding)


🤖 Generated with [Claude Code](https://claude.com/claude-code)