### PR TITLE
Add changelog synthesizer for release drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ make fmt
 Releases are automated via GoReleaser. Pushing a version tag triggers GitHub Actions to build binaries and update the Homebrew formula.
 
 ```bash
-# Draft changelog text from commits since the latest semver tag
+# Draft changelog text from commits since the latest semver tag on the current history
 td changelog --version v0.2.0 > /tmp/td-changelog.md
 
 # Create and push an annotated tag (triggers automated release)

--- a/README.md
+++ b/README.md
@@ -215,12 +215,17 @@ make fmt
 Releases are automated via GoReleaser. Pushing a version tag triggers GitHub Actions to build binaries and update the Homebrew formula.
 
 ```bash
+# Draft changelog text from commits since the latest semver tag
+td changelog --version v0.2.0 > /tmp/td-changelog.md
+
 # Create and push an annotated tag (triggers automated release)
 make release VERSION=v0.2.0
 
 # Homebrew users get the update via:
 # brew upgrade td
 ```
+
+Review and polish the generated markdown before pasting it into `CHANGELOG.md`. Use `--from` / `--to` for manual backfills and `--include-meta` if you want docs/test/chore/ci commits included in the draft.
 
 ## Core Workflow
 

--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -28,8 +28,8 @@ func newChangelogCmd() *cobra.Command {
 		GroupID: "system",
 		Long: `Generate a paste-ready Markdown changelog entry from commits in a git range.
 
-By default, td uses the latest semver tag as the start of the range and HEAD as
-the end of the range.`,
+By default, td uses the latest semver tag reachable from the end revision as the
+start of the range and HEAD as the end of the range.`,
 		Example: `  td changelog --version v0.44.0
   td changelog --version v0.44.0 --date 2026-04-06
   td changelog --version v0.44.0 --from v0.43.0 --to HEAD
@@ -64,8 +64,13 @@ the end of the range.`,
 			from = strings.TrimSpace(from)
 			to = strings.TrimSpace(to)
 
+			targetRev := to
+			if targetRev == "" {
+				targetRev = "HEAD"
+			}
+
 			if from == "" {
-				from, err = gitpkg.GetLatestSemverTagInDir(repoDir)
+				from, err = gitpkg.GetLatestSemverTagReachableFromInDir(repoDir, targetRev)
 				if err != nil {
 					switch {
 					case errors.Is(err, gitpkg.ErrNoSemverTags):
@@ -110,7 +115,7 @@ the end of the range.`,
 	}
 
 	cmd.Flags().StringVar(&version, "version", "", "release version for the generated heading (required)")
-	cmd.Flags().StringVar(&from, "from", "", "starting revision (default: latest semver tag)")
+	cmd.Flags().StringVar(&from, "from", "", "starting revision (default: latest semver tag reachable from --to)")
 	cmd.Flags().StringVar(&to, "to", "HEAD", "ending revision (default: HEAD)")
 	cmd.Flags().StringVar(&releaseDate, "date", time.Now().Format("2006-01-02"), "release date in YYYY-MM-DD format")
 	cmd.Flags().BoolVar(&includeMeta, "include-meta", false, "include docs/test/ci/chore commits in the output")

--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	changelogpkg "github.com/marcus/td/internal/changelog"
+	gitpkg "github.com/marcus/td/internal/git"
+	"github.com/spf13/cobra"
+)
+
+var releaseVersionPattern = regexp.MustCompile(`^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$`)
+
+func newChangelogCmd() *cobra.Command {
+	var version string
+	var from string
+	var to string
+	var releaseDate string
+	var includeMeta bool
+
+	cmd := &cobra.Command{
+		Use:     "changelog",
+		Short:   "Generate a changelog entry from git commits",
+		GroupID: "system",
+		Long: `Generate a paste-ready Markdown changelog entry from commits in a git range.
+
+By default, td uses the latest semver tag as the start of the range and HEAD as
+the end of the range.`,
+		Example: `  td changelog --version v0.44.0
+  td changelog --version v0.44.0 --date 2026-04-06
+  td changelog --version v0.44.0 --from v0.43.0 --to HEAD
+  td changelog --version v0.44.0 --include-meta`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			version = strings.TrimSpace(version)
+			if version == "" {
+				return errors.New("--version is required")
+			}
+			if !releaseVersionPattern.MatchString(version) {
+				return fmt.Errorf("invalid --version %q: expected semver like v1.2.3", version)
+			}
+
+			dateValue, err := time.Parse("2006-01-02", releaseDate)
+			if err != nil {
+				return fmt.Errorf("invalid --date %q: expected YYYY-MM-DD", releaseDate)
+			}
+
+			repoStartDir, err := changelogRepoStartDir()
+			if err != nil {
+				return err
+			}
+
+			repoDir, err := gitpkg.GetRootDirInDir(repoStartDir)
+			if err != nil {
+				if errors.Is(err, gitpkg.ErrNotRepository) {
+					return errors.New("not a git repository")
+				}
+				return err
+			}
+
+			from = strings.TrimSpace(from)
+			to = strings.TrimSpace(to)
+
+			if from == "" {
+				from, err = gitpkg.GetLatestSemverTagInDir(repoDir)
+				if err != nil {
+					switch {
+					case errors.Is(err, gitpkg.ErrNoSemverTags):
+						return errors.New("no semver tags found; use --from to specify a starting revision")
+					case errors.Is(err, gitpkg.ErrNotRepository):
+						return errors.New("not a git repository")
+					default:
+						return err
+					}
+				}
+			}
+			if to == "" {
+				to = "HEAD"
+			}
+
+			commits, err := gitpkg.ListCommitsInRangeInDir(repoDir, from, to)
+			if err != nil {
+				if errors.Is(err, gitpkg.ErrNotRepository) {
+					return errors.New("not a git repository")
+				}
+				return err
+			}
+			if len(commits) == 0 {
+				return fmt.Errorf("no commits found in range %s..%s", from, to)
+			}
+
+			rendered, err := changelogpkg.Render(commits, changelogpkg.Options{
+				Version:     version,
+				Date:        dateValue,
+				IncludeMeta: includeMeta,
+			})
+			if err != nil {
+				if errors.Is(err, changelogpkg.ErrNoEntries) {
+					return fmt.Errorf("no changelog-worthy commits found in range %s..%s (try --include-meta)", from, to)
+				}
+				return err
+			}
+
+			fmt.Print(rendered)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&version, "version", "", "release version for the generated heading (required)")
+	cmd.Flags().StringVar(&from, "from", "", "starting revision (default: latest semver tag)")
+	cmd.Flags().StringVar(&to, "to", "HEAD", "ending revision (default: HEAD)")
+	cmd.Flags().StringVar(&releaseDate, "date", time.Now().Format("2006-01-02"), "release date in YYYY-MM-DD format")
+	cmd.Flags().BoolVar(&includeMeta, "include-meta", false, "include docs/test/ci/chore commits in the output")
+
+	return cmd
+}
+
+var changelogCmd = newChangelogCmd()
+
+func init() {
+	rootCmd.AddCommand(changelogCmd)
+}
+
+func changelogRepoStartDir() (string, error) {
+	if baseDirOverride != nil {
+		return *baseDirOverride, nil
+	}
+	if workDirFlag != "" {
+		return normalizeWorkDir(workDirFlag), nil
+	}
+	if envDir := os.Getenv("TD_WORK_DIR"); envDir != "" {
+		return normalizeWorkDir(envDir), nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("determine working directory: %w", err)
+	}
+	return cwd, nil
+}

--- a/cmd/changelog_test.go
+++ b/cmd/changelog_test.go
@@ -38,7 +38,11 @@ func runGitCommand(t *testing.T, dir string, args ...string) string {
 func writeAndCommit(t *testing.T, dir, fileName, contents, subject string, body ...string) string {
 	t.Helper()
 
-	if err := os.WriteFile(filepath.Join(dir, fileName), []byte(contents), 0644); err != nil {
+	fullPath := filepath.Join(dir, fileName)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+		t.Fatalf("mkdir for %s failed: %v", fileName, err)
+	}
+	if err := os.WriteFile(fullPath, []byte(contents), 0644); err != nil {
 		t.Fatalf("write %s failed: %v", fileName, err)
 	}
 	runGitCommand(t, dir, "add", fileName)
@@ -50,6 +54,11 @@ func writeAndCommit(t *testing.T, dir, fileName, contents, subject string, body 
 	runGitCommand(t, dir, args...)
 
 	return runGitCommand(t, dir, "rev-parse", "HEAD")
+}
+
+func currentBranchName(t *testing.T, dir string) string {
+	t.Helper()
+	return runGitCommand(t, dir, "rev-parse", "--abbrev-ref", "HEAD")
 }
 
 func runChangelogCommand(t *testing.T, dir string, args ...string) (string, error) {
@@ -137,6 +146,43 @@ func TestChangelogCommandExplicitRangeOverride(t *testing.T) {
 	}
 }
 
+func TestChangelogCommandDefaultsFromLatestReachableSemverTag(t *testing.T) {
+	dir := initChangelogRepo(t)
+	runGitCommand(t, dir, "tag", "v0.1.0")
+
+	writeAndCommit(t, dir, "feature-a.txt", "feature a\n", "feat: add commit on main before release branch")
+
+	branch := currentBranchName(t, dir)
+	runGitCommand(t, dir, "checkout", "-b", "release/v0.2.0")
+	writeAndCommit(t, dir, "release.txt", "release\n", "fix: release-branch-only patch")
+	runGitCommand(t, dir, "tag", "v0.2.0")
+	runGitCommand(t, dir, "checkout", branch)
+
+	writeAndCommit(t, dir, "feature-b.txt", "feature b\n", "fix: add post-release bug fix")
+
+	out, err := runChangelogCommand(t, dir,
+		"--version", "v0.3.0",
+		"--date", "2026-04-06",
+	)
+	if err != nil {
+		t.Fatalf("command returned error: %v", err)
+	}
+
+	wantSnippets := []string{
+		"- Add commit on main before release branch",
+		"- Add post-release bug fix",
+	}
+	for _, snippet := range wantSnippets {
+		if !strings.Contains(out, snippet) {
+			t.Fatalf("expected output to contain %q\nfull output:\n%s", snippet, out)
+		}
+	}
+
+	if strings.Contains(out, "release-branch-only patch") {
+		t.Fatalf("did not expect release branch commit in output:\n%s", out)
+	}
+}
+
 func TestChangelogCommandErrorsWithoutVersion(t *testing.T) {
 	dir := initChangelogRepo(t)
 	runGitCommand(t, dir, "tag", "v0.1.0")
@@ -172,5 +218,19 @@ func TestChangelogCommandErrorsWithoutTagsWhenFromUnset(t *testing.T) {
 	)
 	if err == nil || !strings.Contains(err.Error(), "no semver tags found; use --from to specify a starting revision") {
 		t.Fatalf("expected no tags error, got %v", err)
+	}
+}
+
+func TestChangelogCommandFiltersUppercaseMetaByDefault(t *testing.T) {
+	dir := initChangelogRepo(t)
+	runGitCommand(t, dir, "tag", "v0.1.0")
+	writeAndCommit(t, dir, ".github/workflows/ci.yml", "name: ci\n", "CI: fix pipeline")
+
+	_, err := runChangelogCommand(t, dir,
+		"--version", "v0.2.0",
+		"--date", "2026-04-06",
+	)
+	if err == nil || !strings.Contains(err.Error(), "no changelog-worthy commits found in range v0.1.0..HEAD") {
+		t.Fatalf("expected filtered-meta error, got %v", err)
 	}
 }

--- a/cmd/changelog_test.go
+++ b/cmd/changelog_test.go
@@ -1,0 +1,176 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func initChangelogRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	runGitCommand(t, dir, "init")
+	runGitCommand(t, dir, "config", "user.email", "test@example.com")
+	runGitCommand(t, dir, "config", "user.name", "Test User")
+
+	writeAndCommit(t, dir, "README.md", "# Test\n", "chore: initial commit")
+
+	return dir
+}
+
+func runGitCommand(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v (%s)", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func writeAndCommit(t *testing.T, dir, fileName, contents, subject string, body ...string) string {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(dir, fileName), []byte(contents), 0644); err != nil {
+		t.Fatalf("write %s failed: %v", fileName, err)
+	}
+	runGitCommand(t, dir, "add", fileName)
+
+	args := []string{"commit", "-m", subject}
+	for _, paragraph := range body {
+		args = append(args, "-m", paragraph)
+	}
+	runGitCommand(t, dir, args...)
+
+	return runGitCommand(t, dir, "rev-parse", "HEAD")
+}
+
+func runChangelogCommand(t *testing.T, dir string, args ...string) (string, error) {
+	t.Helper()
+
+	saveAndRestoreGlobals(t)
+	baseDir := dir
+	baseDirOverride = &baseDir
+
+	command := newChangelogCmd()
+	command.SilenceUsage = true
+	command.SetArgs(args)
+
+	var output bytes.Buffer
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe failed: %v", err)
+	}
+	os.Stdout = w
+
+	runErr := command.Execute()
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+	_, _ = io.Copy(&output, r)
+
+	return output.String(), runErr
+}
+
+func TestChangelogCommandOutputsMarkdown(t *testing.T) {
+	dir := initChangelogRepo(t)
+	runGitCommand(t, dir, "tag", "v0.1.0")
+	writeAndCommit(t, dir, "feature.txt", "feature\n", "feat: add changelog command")
+	writeAndCommit(t, dir, "fix.txt", "fix\n", "fix: handle explicit range overrides (#70)")
+	writeAndCommit(t, dir, "docs.txt", "docs\n", "docs: document release workflow")
+
+	out, err := runChangelogCommand(t, dir,
+		"--version", "v0.2.0",
+		"--date", "2026-04-06",
+	)
+	if err != nil {
+		t.Fatalf("command returned error: %v", err)
+	}
+
+	wantSnippets := []string{
+		"## [v0.2.0] - 2026-04-06",
+		"### Features",
+		"- Add changelog command",
+		"### Bug Fixes",
+		"- Handle explicit range overrides (#70)",
+	}
+	for _, snippet := range wantSnippets {
+		if !strings.Contains(out, snippet) {
+			t.Fatalf("expected output to contain %q\nfull output:\n%s", snippet, out)
+		}
+	}
+
+	if strings.Contains(out, "document release workflow") {
+		t.Fatalf("expected docs commit to be filtered by default:\n%s", out)
+	}
+}
+
+func TestChangelogCommandExplicitRangeOverride(t *testing.T) {
+	dir := initChangelogRepo(t)
+	base := runGitCommand(t, dir, "rev-parse", "HEAD")
+	first := writeAndCommit(t, dir, "feature.txt", "feature\n", "feat: add scoped entry")
+	writeAndCommit(t, dir, "fix.txt", "fix\n", "fix: should stay out of explicit range")
+
+	out, err := runChangelogCommand(t, dir,
+		"--version", "v0.2.0",
+		"--date", "2026-04-06",
+		"--from", base,
+		"--to", first,
+	)
+	if err != nil {
+		t.Fatalf("command returned error: %v", err)
+	}
+
+	if !strings.Contains(out, "Add scoped entry") {
+		t.Fatalf("expected explicit range commit in output:\n%s", out)
+	}
+	if strings.Contains(out, "should stay out of explicit range") {
+		t.Fatalf("did not expect later commit in output:\n%s", out)
+	}
+}
+
+func TestChangelogCommandErrorsWithoutVersion(t *testing.T) {
+	dir := initChangelogRepo(t)
+	runGitCommand(t, dir, "tag", "v0.1.0")
+	writeAndCommit(t, dir, "feature.txt", "feature\n", "feat: add changelog command")
+
+	_, err := runChangelogCommand(t, dir, "--date", "2026-04-06")
+	if err == nil || !strings.Contains(err.Error(), "--version is required") {
+		t.Fatalf("expected missing version error, got %v", err)
+	}
+}
+
+func TestChangelogCommandErrorsOnEmptyRange(t *testing.T) {
+	dir := initChangelogRepo(t)
+
+	_, err := runChangelogCommand(t, dir,
+		"--version", "v0.2.0",
+		"--date", "2026-04-06",
+		"--from", "HEAD",
+		"--to", "HEAD",
+	)
+	if err == nil || !strings.Contains(err.Error(), "no commits found in range HEAD..HEAD") {
+		t.Fatalf("expected empty range error, got %v", err)
+	}
+}
+
+func TestChangelogCommandErrorsWithoutTagsWhenFromUnset(t *testing.T) {
+	dir := initChangelogRepo(t)
+	writeAndCommit(t, dir, "feature.txt", "feature\n", "feat: add changelog command")
+
+	_, err := runChangelogCommand(t, dir,
+		"--version", "v0.2.0",
+		"--date", "2026-04-06",
+	)
+	if err == nil || !strings.Contains(err.Error(), "no semver tags found; use --from to specify a starting revision") {
+		t.Fatalf("expected no tags error, got %v", err)
+	}
+}

--- a/docs/guides/releasing-new-version.md
+++ b/docs/guides/releasing-new-version.md
@@ -35,7 +35,7 @@ git tag -l | sort -V | tail -1
 
 ### 2. Generate and Polish the Changelog
 
-Generate a draft entry from commits since the latest version tag:
+Generate a draft entry from commits since the latest version tag reachable from `HEAD`:
 
 ```bash
 td changelog --version vX.Y.Z > /tmp/td-changelog.md

--- a/docs/guides/releasing-new-version.md
+++ b/docs/guides/releasing-new-version.md
@@ -33,9 +33,23 @@ Check current version:
 git tag -l | sort -V | tail -1
 ```
 
-### 2. Update CHANGELOG.md
+### 2. Generate and Polish the Changelog
 
-Add entry at the top of `CHANGELOG.md`:
+Generate a draft entry from commits since the latest version tag:
+
+```bash
+td changelog --version vX.Y.Z > /tmp/td-changelog.md
+```
+
+If you need a manual backfill or want to test a narrower range:
+
+```bash
+td changelog --version vX.Y.Z --from v0.43.0 --to HEAD
+```
+
+Review the generated text and polish it before pasting it at the top of `CHANGELOG.md`. By default, `td changelog` skips merge commits and low-signal `docs:`, `test:`, `ci:`, and `chore:` commits to stay close to the current release-note filters. Add `--include-meta` if you want those included in the draft.
+
+Paste the draft at the top of `CHANGELOG.md` using this structure:
 
 ```markdown
 ## [vX.Y.Z] - YYYY-MM-DD
@@ -134,8 +148,8 @@ Replace `X.Y.Z` with actual version:
 git status
 go test ./...
 
-# Update changelog
-# (Edit CHANGELOG.md, add entry at top)
+# Generate changelog draft, then paste/polish it into CHANGELOG.md
+td changelog --version vX.Y.Z > /tmp/td-changelog.md
 git add CHANGELOG.md
 git commit -m "docs: Update changelog for vX.Y.Z"
 
@@ -154,7 +168,7 @@ brew upgrade td && td version
 
 - [ ] Tests pass (`go test ./...`)
 - [ ] Working tree clean
-- [ ] CHANGELOG.md updated with new version entry
+- [ ] `td changelog --version vX.Y.Z` reviewed and pasted into `CHANGELOG.md`
 - [ ] Changelog committed to git
 - [ ] Version number follows semver
 - [ ] Commits pushed to main

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -16,7 +16,7 @@ var (
 	// ErrNoEntries indicates there were commits in the range, but none survived filtering.
 	ErrNoEntries = errors.New("no changelog entries")
 
-	conventionalPrefixPattern = regexp.MustCompile(`^(?P<type>[a-z]+)(?:\([^)]+\))?(?:!)?:\s*(?P<rest>.+)$`)
+	conventionalPrefixPattern = regexp.MustCompile(`(?i)^(?P<type>[a-z]+)(?:\([^)]+\))?(?:!)?:\s*(?P<rest>.+)$`)
 	internalPrefixPattern     = regexp.MustCompile(`^(?:\[[^\]]+\]\s*)+`)
 	internalSuffixPattern     = regexp.MustCompile(`\s+\(td-[^)]+\)$`)
 	releaseHousekeeping       = []*regexp.Regexp{

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -1,0 +1,224 @@
+package changelog
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/marcus/td/internal/git"
+)
+
+var (
+	// ErrNoEntries indicates there were commits in the range, but none survived filtering.
+	ErrNoEntries = errors.New("no changelog entries")
+
+	conventionalPrefixPattern = regexp.MustCompile(`^(?P<type>[a-z]+)(?:\([^)]+\))?(?:!)?:\s*(?P<rest>.+)$`)
+	internalPrefixPattern     = regexp.MustCompile(`^(?:\[[^\]]+\]\s*)+`)
+	internalSuffixPattern     = regexp.MustCompile(`\s+\(td-[^)]+\)$`)
+	releaseHousekeeping       = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)^docs:\s+update changelog for v\d+\.\d+\.\d+`),
+		regexp.MustCompile(`(?i)^chore(?:\([^)]+\))?:\s+(?:prepare|cut|publish|release)\s+v\d+\.\d+\.\d+`),
+		regexp.MustCompile(`(?i)^release\s+v\d+\.\d+\.\d+`),
+		regexp.MustCompile(`(?i)^bump version to v\d+\.\d+\.\d+`),
+	}
+)
+
+type section string
+
+const (
+	sectionFeatures      section = "Features"
+	sectionBugFixes      section = "Bug Fixes"
+	sectionImprovements  section = "Improvements"
+	sectionDocumentation section = "Documentation"
+	sectionOtherChanges  section = "Other Changes"
+)
+
+var sectionOrder = []section{
+	sectionFeatures,
+	sectionBugFixes,
+	sectionImprovements,
+	sectionDocumentation,
+	sectionOtherChanges,
+}
+
+// Options controls changelog rendering.
+type Options struct {
+	Version     string
+	Date        time.Time
+	IncludeMeta bool
+}
+
+// Render converts git commits into a paste-ready markdown changelog section.
+func Render(commits []git.Commit, opts Options) (string, error) {
+	if strings.TrimSpace(opts.Version) == "" {
+		return "", errors.New("version is required")
+	}
+	if opts.Date.IsZero() {
+		return "", errors.New("date is required")
+	}
+
+	grouped := map[section][]string{}
+	entryCount := 0
+
+	for _, commit := range commits {
+		entry, ok := classifyCommit(commit, opts.IncludeMeta)
+		if !ok {
+			continue
+		}
+		grouped[entry.section] = append(grouped[entry.section], entry.text)
+		entryCount++
+	}
+
+	if entryCount == 0 {
+		return "", ErrNoEntries
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "## [%s] - %s\n\n", opts.Version, opts.Date.Format("2006-01-02"))
+
+	for _, sec := range sectionOrder {
+		items := grouped[sec]
+		if len(items) == 0 {
+			continue
+		}
+
+		fmt.Fprintf(&b, "### %s\n", sec)
+		for _, item := range items {
+			fmt.Fprintf(&b, "- %s\n", item)
+		}
+		b.WriteString("\n")
+	}
+
+	return strings.TrimRight(b.String(), "\n") + "\n", nil
+}
+
+type entry struct {
+	section section
+	text    string
+}
+
+func classifyCommit(commit git.Commit, includeMeta bool) (entry, bool) {
+	subject := strings.TrimSpace(commit.Subject)
+	if subject == "" {
+		return entry{}, false
+	}
+	if isMergeCommit(subject) || isReleaseHousekeeping(subject) {
+		return entry{}, false
+	}
+
+	subject = cleanSubject(subject)
+	if subject == "" {
+		return entry{}, false
+	}
+
+	kind, remainder := conventionalKind(subject)
+	switch kind {
+	case "feat":
+		return entry{section: sectionFeatures, text: cleanBulletText(remainder)}, true
+	case "fix":
+		return entry{section: sectionBugFixes, text: cleanBulletText(remainder)}, true
+	case "docs":
+		if !includeMeta {
+			return entry{}, false
+		}
+		return entry{section: sectionDocumentation, text: cleanBulletText(remainder)}, true
+	case "perf", "refactor", "build", "style", "revert":
+		return entry{section: sectionImprovements, text: cleanBulletText(remainder)}, true
+	case "test", "ci", "chore":
+		if !includeMeta {
+			return entry{}, false
+		}
+		return entry{section: sectionImprovements, text: cleanBulletText(remainder)}, true
+	}
+
+	guessedSection, ok := classifyFreeform(subject, includeMeta)
+	if !ok {
+		return entry{}, false
+	}
+
+	return entry{section: guessedSection, text: cleanBulletText(subject)}, true
+}
+
+func isMergeCommit(subject string) bool {
+	return strings.HasPrefix(subject, "Merge ")
+}
+
+func isReleaseHousekeeping(subject string) bool {
+	for _, pattern := range releaseHousekeeping {
+		if pattern.MatchString(subject) {
+			return true
+		}
+	}
+	return false
+}
+
+func cleanSubject(subject string) string {
+	subject = strings.TrimSpace(subject)
+	subject = internalPrefixPattern.ReplaceAllString(subject, "")
+	subject = internalSuffixPattern.ReplaceAllString(subject, "")
+	return strings.TrimSpace(subject)
+}
+
+func conventionalKind(subject string) (string, string) {
+	matches := conventionalPrefixPattern.FindStringSubmatch(subject)
+	if len(matches) != 3 {
+		return "", ""
+	}
+	return strings.ToLower(matches[1]), strings.TrimSpace(matches[2])
+}
+
+func classifyFreeform(subject string, includeMeta bool) (section, bool) {
+	lower := strings.ToLower(subject)
+	candidates := []string{lower}
+	if _, tail, ok := strings.Cut(lower, ": "); ok && strings.TrimSpace(tail) != "" {
+		candidates = append(candidates, strings.TrimSpace(tail))
+	}
+
+	switch {
+	case hasLeadingVerb(candidates, "add", "introduce", "support", "enable", "implement", "show"):
+		return sectionFeatures, true
+	case hasLeadingVerb(candidates, "fix", "resolve", "correct", "prevent", "stabilize", "restore"):
+		return sectionBugFixes, true
+	case hasLeadingVerb(candidates, "document", "docs", "readme"):
+		if !includeMeta {
+			return "", false
+		}
+		return sectionDocumentation, true
+	case hasLeadingVerb(candidates, "clean up", "clarify", "align", "reduce", "increase", "improve", "simplify", "update", "expose", "refine"):
+		return sectionImprovements, true
+	default:
+		return sectionOtherChanges, true
+	}
+}
+
+func hasLeadingVerb(subjects []string, verbs ...string) bool {
+	for _, subject := range subjects {
+		for _, verb := range verbs {
+			if subject == verb || strings.HasPrefix(subject, verb+" ") || strings.HasPrefix(subject, verb+":") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func cleanBulletText(text string) string {
+	text = strings.TrimSpace(text)
+	text = strings.TrimSuffix(text, ".")
+	if text == "" {
+		return text
+	}
+
+	r, size := utf8.DecodeRuneInString(text)
+	if r == utf8.RuneError && size == 0 {
+		return text
+	}
+	if unicode.IsLower(r) {
+		return string(unicode.ToUpper(r)) + text[size:]
+	}
+	return text
+}

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -1,0 +1,98 @@
+package changelog
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/marcus/td/internal/git"
+)
+
+func TestRenderGroupsAndCleansCommits(t *testing.T) {
+	commits := []git.Commit{
+		{Subject: "feat: add rich text file input for issues"},
+		{Subject: "fix: add missing -l shorthand for multivalue flags (#70)"},
+		{Subject: "[td-377aae] Review commands: clarify stale concurrent transitions"},
+		{Subject: "Merge pull request #91 from marcus/dispatch/td-527bd4-0006"},
+		{Subject: "docs: Update changelog for v0.43.0"},
+		{Subject: "[td-79fac9] Show colored status line at top of td issue detail modal"},
+	}
+
+	got, err := Render(commits, Options{
+		Version: "v0.44.0",
+		Date:    time.Date(2026, 4, 6, 0, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	wantSnippets := []string{
+		"## [v0.44.0] - 2026-04-06",
+		"### Features",
+		"- Add rich text file input for issues",
+		"- Show colored status line at top of td issue detail modal",
+		"### Bug Fixes",
+		"- Add missing -l shorthand for multivalue flags (#70)",
+		"### Improvements",
+		"- Review commands: clarify stale concurrent transitions",
+	}
+
+	for _, snippet := range wantSnippets {
+		if !strings.Contains(got, snippet) {
+			t.Fatalf("expected output to contain %q\nfull output:\n%s", snippet, got)
+		}
+	}
+
+	unwanted := []string{
+		"Merge pull request",
+		"Update changelog for v0.43.0",
+	}
+	for _, snippet := range unwanted {
+		if strings.Contains(got, snippet) {
+			t.Fatalf("did not expect output to contain %q\nfull output:\n%s", snippet, got)
+		}
+	}
+}
+
+func TestRenderIncludesMetaWhenRequested(t *testing.T) {
+	commits := []git.Commit{
+		{Subject: "docs: document release workflow caveats"},
+		{Subject: "test: cover explicit range overrides"},
+	}
+
+	got, err := Render(commits, Options{
+		Version:     "v0.44.0",
+		Date:        time.Date(2026, 4, 6, 0, 0, 0, 0, time.UTC),
+		IncludeMeta: true,
+	})
+	if err != nil {
+		t.Fatalf("Render returned error: %v", err)
+	}
+
+	if !strings.Contains(got, "### Documentation") {
+		t.Fatalf("expected documentation section in output:\n%s", got)
+	}
+	if !strings.Contains(got, "- Document release workflow caveats") {
+		t.Fatalf("expected docs bullet in output:\n%s", got)
+	}
+	if !strings.Contains(got, "- Cover explicit range overrides") {
+		t.Fatalf("expected test bullet in output:\n%s", got)
+	}
+}
+
+func TestRenderReturnsErrNoEntriesWhenEverythingFiltered(t *testing.T) {
+	commits := []git.Commit{
+		{Subject: "docs: Update changelog for v0.43.0"},
+		{Subject: "Merge pull request #91 from marcus/dispatch/td-527bd4-0006"},
+		{Subject: "test: exercise explicit range overrides"},
+	}
+
+	_, err := Render(commits, Options{
+		Version: "v0.44.0",
+		Date:    time.Date(2026, 4, 6, 0, 0, 0, 0, time.UTC),
+	})
+	if !errors.Is(err, ErrNoEntries) {
+		t.Fatalf("expected ErrNoEntries, got %v", err)
+	}
+}

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -59,6 +59,7 @@ func TestRenderIncludesMetaWhenRequested(t *testing.T) {
 	commits := []git.Commit{
 		{Subject: "docs: document release workflow caveats"},
 		{Subject: "test: cover explicit range overrides"},
+		{Subject: "CI: fix release pipeline"},
 	}
 
 	got, err := Render(commits, Options{
@@ -78,6 +79,23 @@ func TestRenderIncludesMetaWhenRequested(t *testing.T) {
 	}
 	if !strings.Contains(got, "- Cover explicit range overrides") {
 		t.Fatalf("expected test bullet in output:\n%s", got)
+	}
+	if !strings.Contains(got, "- Fix release pipeline") {
+		t.Fatalf("expected CI bullet in output:\n%s", got)
+	}
+}
+
+func TestRenderFiltersUppercaseMetaByDefault(t *testing.T) {
+	commits := []git.Commit{
+		{Subject: "CI: fix release pipeline"},
+	}
+
+	_, err := Render(commits, Options{
+		Version: "v0.44.0",
+		Date:    time.Date(2026, 4, 6, 0, 0, 0, 0, time.UTC),
+	})
+	if !errors.Is(err, ErrNoEntries) {
+		t.Fatalf("expected ErrNoEntries, got %v", err)
 	}
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -101,19 +101,32 @@ func GetCommitsSince(sha string) (int, error) {
 	return count, nil
 }
 
-// GetLatestSemverTag returns the latest semver-compatible tag in the current repository.
+// GetLatestSemverTag returns the latest semver-compatible tag reachable from HEAD
+// in the current repository.
 func GetLatestSemverTag() (string, error) {
 	return GetLatestSemverTagInDir("")
 }
 
-// GetLatestSemverTagInDir returns the latest semver-compatible tag in the given repository.
+// GetLatestSemverTagInDir returns the latest semver-compatible tag reachable
+// from HEAD in the given repository.
 func GetLatestSemverTagInDir(dir string) (string, error) {
-	output, err := runGitInDir(dir, "tag", "--list", "--sort=-version:refname", "v*")
+	return GetLatestSemverTagReachableFromInDir(dir, "HEAD")
+}
+
+// GetLatestSemverTagReachableFromInDir returns the highest semver-compatible
+// tag reachable from the given revision in the provided repository.
+func GetLatestSemverTagReachableFromInDir(dir, rev string) (string, error) {
+	rev = strings.TrimSpace(rev)
+	if rev == "" {
+		rev = "HEAD"
+	}
+
+	output, err := runGitInDir(dir, "tag", "--merged", rev, "--list", "--sort=-version:refname", "v*")
 	if err != nil {
 		if errors.Is(err, ErrNotRepository) {
 			return "", err
 		}
-		return "", fmt.Errorf("list git tags: %w", err)
+		return "", fmt.Errorf("list git tags reachable from %s: %w", rev, err)
 	}
 
 	for _, line := range strings.Split(output, "\n") {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -4,10 +4,22 @@ package git
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
+	"time"
+)
+
+var (
+	// ErrNotRepository indicates the target directory is not a git repository.
+	ErrNotRepository = errors.New("not a git repository")
+	// ErrNoSemverTags indicates no semver-compatible tags were found.
+	ErrNoSemverTags = errors.New("no semver tags found")
+
+	semverTagPattern = regexp.MustCompile(`^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$`)
 )
 
 // State represents the current git state
@@ -20,26 +32,40 @@ type State struct {
 	DirtyFiles int
 }
 
+// Commit represents structured metadata for a git commit.
+type Commit struct {
+	Hash       string
+	Subject    string
+	Body       string
+	AuthorDate time.Time
+}
+
 // GetState returns the current git state
 func GetState() (*State, error) {
+	return GetStateInDir("")
+}
+
+// GetStateInDir returns the current git state for a specific repository
+// directory. An empty dir uses the current working directory.
+func GetStateInDir(dir string) (*State, error) {
 	state := &State{}
 
 	// Get current commit SHA
-	sha, err := runGit("rev-parse", "HEAD")
+	sha, err := runGitInDir(dir, "rev-parse", "HEAD")
 	if err != nil {
-		return nil, fmt.Errorf("not a git repository")
+		return nil, ErrNotRepository
 	}
 	state.CommitSHA = strings.TrimSpace(sha)
 
 	// Get current branch
-	branch, err := runGit("rev-parse", "--abbrev-ref", "HEAD")
+	branch, err := runGitInDir(dir, "rev-parse", "--abbrev-ref", "HEAD")
 	if err != nil {
 		branch = "HEAD"
 	}
 	state.Branch = strings.TrimSpace(branch)
 
 	// Get status
-	status, _ := runGit("status", "--porcelain")
+	status, _ := runGitInDir(dir, "status", "--porcelain")
 	lines := strings.Split(strings.TrimSpace(status), "\n")
 
 	if status == "" || (len(lines) == 1 && lines[0] == "") {
@@ -73,6 +99,60 @@ func GetCommitsSince(sha string) (int, error) {
 		return 0, err
 	}
 	return count, nil
+}
+
+// GetLatestSemverTag returns the latest semver-compatible tag in the current repository.
+func GetLatestSemverTag() (string, error) {
+	return GetLatestSemverTagInDir("")
+}
+
+// GetLatestSemverTagInDir returns the latest semver-compatible tag in the given repository.
+func GetLatestSemverTagInDir(dir string) (string, error) {
+	output, err := runGitInDir(dir, "tag", "--list", "--sort=-version:refname", "v*")
+	if err != nil {
+		if errors.Is(err, ErrNotRepository) {
+			return "", err
+		}
+		return "", fmt.Errorf("list git tags: %w", err)
+	}
+
+	for _, line := range strings.Split(output, "\n") {
+		tag := strings.TrimSpace(line)
+		if tag == "" {
+			continue
+		}
+		if semverTagPattern.MatchString(tag) {
+			return tag, nil
+		}
+	}
+
+	return "", ErrNoSemverTags
+}
+
+// ListCommitsInRange returns structured commits for the given revision range in
+// chronological order.
+func ListCommitsInRange(from, to string) ([]Commit, error) {
+	return ListCommitsInRangeInDir("", from, to)
+}
+
+// ListCommitsInRangeInDir returns structured commits for the given revision
+// range in chronological order from the specified repository directory.
+func ListCommitsInRangeInDir(dir, from, to string) ([]Commit, error) {
+	rangeArg := revisionRange(from, to)
+	output, err := runGitInDir(dir,
+		"log",
+		"--reverse",
+		"--format=%H%x1f%s%x1f%b%x1f%aI%x1e",
+		rangeArg,
+	)
+	if err != nil {
+		if errors.Is(err, ErrNotRepository) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("list commits for %s: %w", rangeArg, err)
+	}
+
+	return parseCommitLog(output)
 }
 
 // GetChangedFilesSince returns changed files since a given SHA
@@ -185,7 +265,12 @@ func IsRepo() bool {
 
 // GetRootDir returns the git repository root directory
 func GetRootDir() (string, error) {
-	output, err := runGit("rev-parse", "--show-toplevel")
+	return GetRootDirInDir("")
+}
+
+// GetRootDirInDir returns the git repository root directory for a specific directory.
+func GetRootDirInDir(dir string) (string, error) {
+	output, err := runGitInDir(dir, "rev-parse", "--show-toplevel")
 	if err != nil {
 		return "", err
 	}
@@ -193,15 +278,77 @@ func GetRootDir() (string, error) {
 }
 
 func runGit(args ...string) (string, error) {
+	return runGitInDir("", args...)
+}
+
+func runGitInDir(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()
 	if err != nil {
-		return "", fmt.Errorf("%s: %s", err, stderr.String())
+		errText := strings.TrimSpace(stderr.String())
+		if strings.Contains(errText, "not a git repository") {
+			return "", ErrNotRepository
+		}
+		if errText == "" {
+			errText = err.Error()
+		}
+		return "", fmt.Errorf("%s: %s", err, errText)
 	}
 
 	return stdout.String(), nil
+}
+
+func revisionRange(from, to string) string {
+	switch {
+	case from != "" && to != "":
+		return from + ".." + to
+	case from != "":
+		return from + "..HEAD"
+	case to != "":
+		return to
+	default:
+		return "HEAD"
+	}
+}
+
+func parseCommitLog(output string) ([]Commit, error) {
+	output = strings.TrimSuffix(output, "\x1e")
+	if strings.TrimSpace(output) == "" {
+		return nil, nil
+	}
+
+	records := strings.Split(output, "\x1e")
+	commits := make([]Commit, 0, len(records))
+	for _, record := range records {
+		record = strings.TrimSpace(record)
+		if record == "" {
+			continue
+		}
+
+		fields := strings.Split(record, "\x1f")
+		if len(fields) != 4 {
+			return nil, fmt.Errorf("unexpected git log record: %q", record)
+		}
+
+		authorDate, err := time.Parse(time.RFC3339, strings.TrimSpace(fields[3]))
+		if err != nil {
+			return nil, fmt.Errorf("parse author date %q: %w", fields[3], err)
+		}
+
+		commits = append(commits, Commit{
+			Hash:       strings.TrimSpace(fields[0]),
+			Subject:    strings.TrimSpace(fields[1]),
+			Body:       strings.TrimSpace(fields[2]),
+			AuthorDate: authorDate,
+		})
+	}
+
+	return commits, nil
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -43,6 +44,25 @@ func runCmd(dir string, name string, args ...string) error {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	return cmd.Run()
+}
+
+func createCommit(t *testing.T, dir, fileName, contents, subject string, body ...string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(dir, fileName), []byte(contents), 0644); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	if err := runCmd(dir, "git", "add", fileName); err != nil {
+		t.Fatalf("Failed to git add: %v", err)
+	}
+
+	args := []string{"commit", "-m", subject}
+	for _, paragraph := range body {
+		args = append(args, "-m", paragraph)
+	}
+	if err := runCmd(dir, "git", args...); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
 }
 
 // TestParseStatOutputBasic tests parsing git diff --stat output
@@ -467,5 +487,87 @@ func TestStateBranchName(t *testing.T) {
 	// The branch should be either 'main', 'master', or some default
 	if state.Branch != "main" && state.Branch != "master" && state.Branch != "HEAD" {
 		t.Logf("Branch name is %q (expected main/master/HEAD)", state.Branch)
+	}
+}
+
+func TestGetLatestSemverTagInDir(t *testing.T) {
+	dir := initTestRepo(t)
+
+	if err := runCmd(dir, "git", "tag", "not-a-release"); err != nil {
+		t.Fatalf("Failed to create non-semver tag: %v", err)
+	}
+	if err := runCmd(dir, "git", "tag", "v0.1.0"); err != nil {
+		t.Fatalf("Failed to create tag: %v", err)
+	}
+
+	createCommit(t, dir, "feature.txt", "feature\n", "feat: add changelog generator")
+
+	if err := runCmd(dir, "git", "tag", "v0.2.0"); err != nil {
+		t.Fatalf("Failed to create tag: %v", err)
+	}
+
+	got, err := GetLatestSemverTagInDir(dir)
+	if err != nil {
+		t.Fatalf("GetLatestSemverTagInDir failed: %v", err)
+	}
+	if got != "v0.2.0" {
+		t.Fatalf("GetLatestSemverTagInDir = %q, want %q", got, "v0.2.0")
+	}
+}
+
+func TestGetLatestSemverTagInDirNoTags(t *testing.T) {
+	dir := initTestRepo(t)
+
+	_, err := GetLatestSemverTagInDir(dir)
+	if err != ErrNoSemverTags {
+		t.Fatalf("GetLatestSemverTagInDir error = %v, want %v", err, ErrNoSemverTags)
+	}
+}
+
+func TestListCommitsInRangeInDir(t *testing.T) {
+	dir := initTestRepo(t)
+
+	if err := runCmd(dir, "git", "tag", "v0.1.0"); err != nil {
+		t.Fatalf("Failed to create tag: %v", err)
+	}
+
+	createCommit(t, dir, "feature.txt", "feature\n", "feat: add changelog generator", "Detailed body paragraph")
+	createCommit(t, dir, "fix.txt", "fix\n", "fix: handle explicit --to overrides")
+
+	commits, err := ListCommitsInRangeInDir(dir, "v0.1.0", "HEAD")
+	if err != nil {
+		t.Fatalf("ListCommitsInRangeInDir failed: %v", err)
+	}
+	if len(commits) != 2 {
+		t.Fatalf("expected 2 commits, got %d", len(commits))
+	}
+	if commits[0].Subject != "feat: add changelog generator" {
+		t.Fatalf("first subject = %q", commits[0].Subject)
+	}
+	if !strings.Contains(commits[0].Body, "Detailed body paragraph") {
+		t.Fatalf("expected commit body to be preserved, got %q", commits[0].Body)
+	}
+	if commits[1].Subject != "fix: handle explicit --to overrides" {
+		t.Fatalf("second subject = %q", commits[1].Subject)
+	}
+	if commits[0].AuthorDate.IsZero() || commits[1].AuthorDate.IsZero() {
+		t.Fatal("expected author dates to be populated")
+	}
+}
+
+func TestListCommitsInRangeInDirEmptyRange(t *testing.T) {
+	dir := initTestRepo(t)
+
+	head, err := runGitInDir(dir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse HEAD failed: %v", err)
+	}
+
+	commits, err := ListCommitsInRangeInDir(dir, strings.TrimSpace(head), "HEAD")
+	if err != nil {
+		t.Fatalf("ListCommitsInRangeInDir failed: %v", err)
+	}
+	if len(commits) != 0 {
+		t.Fatalf("expected 0 commits, got %d", len(commits))
 	}
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -65,6 +65,18 @@ func createCommit(t *testing.T, dir, fileName, contents, subject string, body ..
 	}
 }
 
+func createCommitAndReturnSHA(t *testing.T, dir, fileName, contents, subject string, body ...string) string {
+	t.Helper()
+
+	createCommit(t, dir, fileName, contents, subject, body...)
+
+	sha, err := runGitInDir(dir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("Failed to read HEAD: %v", err)
+	}
+	return strings.TrimSpace(sha)
+}
+
 // TestParseStatOutputBasic tests parsing git diff --stat output
 func TestParseStatOutputBasic(t *testing.T) {
 	output := ` file1.go | 10 ++++------
@@ -515,6 +527,43 @@ func TestGetLatestSemverTagInDir(t *testing.T) {
 	}
 }
 
+func TestGetLatestSemverTagInDirUsesReachableTagFromHead(t *testing.T) {
+	dir := initTestRepo(t)
+
+	if err := runCmd(dir, "git", "tag", "v0.1.0"); err != nil {
+		t.Fatalf("Failed to create base tag: %v", err)
+	}
+
+	createCommit(t, dir, "feature-a.txt", "feature A\n", "feat: add commit on main before release branch")
+
+	currentBranch, err := runGitInDir(dir, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		t.Fatalf("Failed to read current branch: %v", err)
+	}
+	currentBranch = strings.TrimSpace(currentBranch)
+
+	if err := runCmd(dir, "git", "checkout", "-b", "release/v0.2.0"); err != nil {
+		t.Fatalf("Failed to create release branch: %v", err)
+	}
+	createCommit(t, dir, "release.txt", "release\n", "fix: release-branch-only patch")
+	if err := runCmd(dir, "git", "tag", "v0.2.0"); err != nil {
+		t.Fatalf("Failed to create release tag: %v", err)
+	}
+	if err := runCmd(dir, "git", "checkout", currentBranch); err != nil {
+		t.Fatalf("Failed to return to %s: %v", currentBranch, err)
+	}
+
+	createCommit(t, dir, "feature-b.txt", "feature B\n", "fix: add post-release bug fix")
+
+	got, err := GetLatestSemverTagInDir(dir)
+	if err != nil {
+		t.Fatalf("GetLatestSemverTagInDir failed: %v", err)
+	}
+	if got != "v0.1.0" {
+		t.Fatalf("GetLatestSemverTagInDir = %q, want %q", got, "v0.1.0")
+	}
+}
+
 func TestGetLatestSemverTagInDirNoTags(t *testing.T) {
 	dir := initTestRepo(t)
 
@@ -552,6 +601,29 @@ func TestListCommitsInRangeInDir(t *testing.T) {
 	}
 	if commits[0].AuthorDate.IsZero() || commits[1].AuthorDate.IsZero() {
 		t.Fatal("expected author dates to be populated")
+	}
+}
+
+func TestGetLatestSemverTagReachableFromInDirUsesExplicitRevision(t *testing.T) {
+	dir := initTestRepo(t)
+
+	if err := runCmd(dir, "git", "tag", "v0.1.0"); err != nil {
+		t.Fatalf("Failed to create base tag: %v", err)
+	}
+
+	firstMainCommit := createCommitAndReturnSHA(t, dir, "feature.txt", "feature\n", "feat: add first mainline commit")
+	createCommit(t, dir, "fix.txt", "fix\n", "fix: add second mainline commit")
+
+	if err := runCmd(dir, "git", "tag", "v0.2.0"); err != nil {
+		t.Fatalf("Failed to create second tag: %v", err)
+	}
+
+	got, err := GetLatestSemverTagReachableFromInDir(dir, firstMainCommit)
+	if err != nil {
+		t.Fatalf("GetLatestSemverTagReachableFromInDir failed: %v", err)
+	}
+	if got != "v0.1.0" {
+		t.Fatalf("GetLatestSemverTagReachableFromInDir = %q, want %q", got, "v0.1.0")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a  command that drafts paste-ready changelog markdown from git commits
- synthesize grouped release notes from structured commit metadata and document the maintainer workflow
- fix review follow-ups so the default range uses the latest semver tag reachable from the target revision and meta commit filtering is case-insensitive

## Testing
- go test ./internal/git ./internal/changelog ./cmd
- go test ./...
- go run . changelog --version v9.9.9 --date 2026-04-06


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: changelog-synth:/Users/marcus/code/td
task-type: changelog-synth
task-title: Changelog Synthesizer
provider: codex
score: 0.7
cost-tier: Low (10-50k)
branch: main
iterations: 2
duration: 31m43s
run-started: 2026-04-06T02:41:33-07:00
nightshift:metadata -->
