### PR TITLE
Fix changelog synthesizer classifier precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Migration status for legacy in-repo guides is tracked in `docs/guides/README.md`
 td/
 ├── cmd/              # Cobra CLI commands (create, start, handoff, review, etc.)
 ├── internal/
+│   ├── changelog/   # Commit-to-markdown changelog synthesis
 │   ├── db/          # SQLite persistence layer (schema.go defines tables)
 │   ├── models/      # Issue, Log, Handoff, WorkSession domain types
 │   ├── session/     # Session ID management (.todos/session file)
@@ -215,6 +216,9 @@ make fmt
 Releases are automated via GoReleaser. Pushing a version tag triggers GitHub Actions to build binaries and update the Homebrew formula.
 
 ```bash
+# Preview the next release notes from the nearest reachable tag to HEAD
+td changelog --version v0.2.0 --date 2026-04-23
+
 # Create and push an annotated tag (triggers automated release)
 make release VERSION=v0.2.0
 
@@ -460,6 +464,17 @@ Analytics are stored locally and help identify workflow patterns. Disable with `
 | ------------ | ----------------------- |
 | Query issues | `td query "expression"` |
 | Search text  | `td search "keyword"`   |
+
+### System
+
+| Action                  | Command                                                                          |
+| ----------------------- | -------------------------------------------------------------------------------- |
+| Generate changelog      | `td changelog [--from <ref>] [--to <ref>] [--version vX.Y.Z] [--date YYYY-MM-DD]` |
+| Initialize project      | `td init`                                                                        |
+| Show version            | `td version`                                                                     |
+| Export data             | `td export`                                                                      |
+| Import data             | `td import`                                                                      |
+| Show usage statistics   | `td stats [subcommand]`                                                          |
 
 ## Live Monitor
 

--- a/cmd/changelog.go
+++ b/cmd/changelog.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	changelogpkg "github.com/marcus/td/internal/changelog"
+	gitutil "github.com/marcus/td/internal/git"
+	"github.com/spf13/cobra"
+)
+
+var changelogCmd = &cobra.Command{
+	Use:     "changelog",
+	Short:   "Generate changelog markdown from git commits",
+	GroupID: "system",
+	Args:    cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		opts, err := changelogCommandOptionsFromFlags(cmd)
+		if err != nil {
+			return err
+		}
+
+		baseDir := getBaseDir()
+		from, to, err := resolveChangelogRange(baseDir, opts.from, opts.to)
+		if err != nil {
+			return err
+		}
+
+		commits, err := gitutil.ListCommitsInRangeInDir(baseDir, from, to)
+		if err != nil {
+			return fmt.Errorf("list commits for %s..%s: %w", from, to, err)
+		}
+
+		markdown, err := changelogpkg.RenderMarkdown(commits, changelogpkg.Options{
+			Version: opts.version,
+			Date:    opts.date,
+		})
+		if err != nil {
+			if errors.Is(err, changelogpkg.ErrNoRelevantCommits) {
+				return fmt.Errorf("no commits found in range %s..%s", from, to)
+			}
+			return err
+		}
+
+		fmt.Print(markdown)
+		return nil
+	},
+}
+
+type changelogCommandOptions struct {
+	from    string
+	to      string
+	version string
+	date    string
+}
+
+func changelogCommandOptionsFromFlags(cmd *cobra.Command) (changelogCommandOptions, error) {
+	from, _ := cmd.Flags().GetString("from")
+	to, _ := cmd.Flags().GetString("to")
+	version, _ := cmd.Flags().GetString("version")
+	date, _ := cmd.Flags().GetString("date")
+
+	opts := changelogCommandOptions{
+		from:    strings.TrimSpace(from),
+		to:      strings.TrimSpace(to),
+		version: strings.TrimSpace(version),
+		date:    strings.TrimSpace(date),
+	}
+
+	if opts.date != "" && opts.version == "" {
+		return changelogCommandOptions{}, fmt.Errorf("--date requires --version")
+	}
+	if opts.date != "" {
+		if _, err := time.Parse("2006-01-02", opts.date); err != nil {
+			return changelogCommandOptions{}, fmt.Errorf("invalid --date %q: expected YYYY-MM-DD", opts.date)
+		}
+	}
+
+	return opts, nil
+}
+
+func resolveChangelogRange(dir, from, to string) (string, string, error) {
+	if to == "" {
+		to = "HEAD"
+	}
+
+	if from == "" {
+		tag, err := gitutil.GetLatestReleaseTagInDir(dir)
+		if err != nil {
+			return "", "", fmt.Errorf("could not determine default changelog range: %w (use --from <ref>)", err)
+		}
+		from = tag
+	}
+
+	if _, err := gitutil.ResolveRefInDir(dir, from); err != nil {
+		return "", "", fmt.Errorf("invalid --from ref %q: %w", from, err)
+	}
+	if _, err := gitutil.ResolveRefInDir(dir, to); err != nil {
+		return "", "", fmt.Errorf("invalid --to ref %q: %w", to, err)
+	}
+
+	return from, to, nil
+}
+
+func init() {
+	changelogCmd.Flags().String("from", "", "start ref for the changelog range (defaults to nearest reachable semver tag)")
+	changelogCmd.Flags().String("to", "HEAD", "end ref for the changelog range")
+	changelogCmd.Flags().String("version", "", "release version to use in the markdown heading")
+	changelogCmd.Flags().String("date", "", "release date for the markdown heading (YYYY-MM-DD)")
+
+	rootCmd.AddCommand(changelogCmd)
+}

--- a/cmd/changelog_test.go
+++ b/cmd/changelog_test.go
@@ -196,6 +196,30 @@ func TestChangelogCommandIgnoresAutosquashCommits(t *testing.T) {
 	}
 }
 
+func TestChangelogCommandPrefersFeatureAndBugHeuristicsOverDocKeywords(t *testing.T) {
+	dir := initChangelogRepo(t)
+	runGitCommand(t, dir, "tag", "v0.1.0")
+	commitRepoFile(t, dir, "README.md", "# test\n\nExamples\n", "add README examples for changelog command")
+	commitRepoFile(t, dir, "README.md", "# test\n\nExamples fixed\n", "fix changelog heading in README")
+	commitRepoFile(t, dir, "docs/release.md", "workflow\n", "document release workflow")
+
+	output, err := runChangelogCommand(t, dir)
+	if err != nil {
+		t.Fatalf("runChangelogCommand failed: %v", err)
+	}
+
+	wantParts := []string{
+		"### Features\n- Add README examples for changelog command",
+		"### Bug Fixes\n- Fix changelog heading in README",
+		"### Documentation\n- Document release workflow",
+	}
+	for _, part := range wantParts {
+		if !strings.Contains(output, part) {
+			t.Fatalf("expected output to contain %q, got:\n%s", part, output)
+		}
+	}
+}
+
 func TestChangelogCommandErrorsOnEmptyRange(t *testing.T) {
 	dir := initChangelogRepo(t)
 	runGitCommand(t, dir, "tag", "v0.1.0")

--- a/cmd/changelog_test.go
+++ b/cmd/changelog_test.go
@@ -1,0 +1,240 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func initChangelogRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	runGitCommand(t, dir, "init")
+	runGitCommand(t, dir, "config", "user.email", "test@example.com")
+	runGitCommand(t, dir, "config", "user.name", "Test User")
+
+	writeRepoFile(t, dir, "README.md", "# test\n")
+	runGitCommand(t, dir, "add", "README.md")
+	runGitCommand(t, dir, "commit", "-m", "Initial commit")
+
+	return dir
+}
+
+func runGitCommand(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v (%s)", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func writeRepoFile(t *testing.T, dir, name, contents string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("MkdirAll failed: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+}
+
+func commitRepoFile(t *testing.T, dir, name, contents, message string) string {
+	t.Helper()
+	writeRepoFile(t, dir, name, contents)
+	runGitCommand(t, dir, "add", name)
+	runGitCommand(t, dir, "commit", "-m", message)
+	return runGitCommand(t, dir, "rev-parse", "HEAD")
+}
+
+func runChangelogCommand(t *testing.T, dir string, args ...string) (string, error) {
+	t.Helper()
+
+	saveAndRestoreGlobals(t)
+	baseDir := dir
+	baseDirOverride = &baseDir
+
+	_ = changelogCmd.Flags().Set("from", "")
+	_ = changelogCmd.Flags().Set("to", "HEAD")
+	_ = changelogCmd.Flags().Set("version", "")
+	_ = changelogCmd.Flags().Set("date", "")
+
+	for i := 0; i < len(args); i += 2 {
+		if err := changelogCmd.Flags().Set(strings.TrimPrefix(args[i], "--"), args[i+1]); err != nil {
+			t.Fatalf("setting flag %s failed: %v", args[i], err)
+		}
+	}
+
+	var output bytes.Buffer
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe failed: %v", err)
+	}
+	os.Stdout = w
+
+	runErr := changelogCmd.RunE(changelogCmd, nil)
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+	_, _ = io.Copy(&output, r)
+
+	return output.String(), runErr
+}
+
+func TestChangelogCommandUsesLatestTagByDefault(t *testing.T) {
+	dir := initChangelogRepo(t)
+	runGitCommand(t, dir, "tag", "v0.1.0")
+	commitRepoFile(t, dir, "feature.txt", "feature\n", "feat: add changelog command")
+	commitRepoFile(t, dir, "fix.txt", "fix\n", "fix: handle empty range")
+
+	output, err := runChangelogCommand(t, dir)
+	if err != nil {
+		t.Fatalf("runChangelogCommand failed: %v", err)
+	}
+
+	if !strings.Contains(output, "## Unreleased") {
+		t.Fatalf("expected unreleased heading, got:\n%s", output)
+	}
+	if !strings.Contains(output, "### Features\n- Add changelog command") {
+		t.Fatalf("expected feature section, got:\n%s", output)
+	}
+	if !strings.Contains(output, "### Bug Fixes\n- Handle empty range") {
+		t.Fatalf("expected bug fix section, got:\n%s", output)
+	}
+	if strings.Contains(output, "Initial commit") {
+		t.Fatalf("expected commits before latest tag to be excluded, got:\n%s", output)
+	}
+}
+
+func TestChangelogCommandSupportsExplicitRange(t *testing.T) {
+	dir := initChangelogRepo(t)
+	runGitCommand(t, dir, "tag", "v0.1.0")
+	midSHA := commitRepoFile(t, dir, "feature.txt", "feature\n", "feat: add changelog command")
+	commitRepoFile(t, dir, "docs.md", "docs\n", "docs: update release guide")
+	commitRepoFile(t, dir, "notes.txt", "notes\n", "Improve release messaging")
+
+	output, err := runChangelogCommand(t, dir, "--from", "v0.1.0", "--to", midSHA)
+	if err != nil {
+		t.Fatalf("runChangelogCommand failed: %v", err)
+	}
+
+	if !strings.Contains(output, "- Add changelog command") {
+		t.Fatalf("expected explicit range commit, got:\n%s", output)
+	}
+	if strings.Contains(output, "Update release guide") || strings.Contains(output, "Improve release messaging") {
+		t.Fatalf("expected output to stop at explicit --to ref, got:\n%s", output)
+	}
+}
+
+func TestChangelogCommandUsesNearestReachableTagByDefault(t *testing.T) {
+	dir := initChangelogRepo(t)
+	runGitCommand(t, dir, "tag", "v2.0.0")
+	commitRepoFile(t, dir, "prep.txt", "prep\n", "feat: release prep")
+	runGitCommand(t, dir, "tag", "v1.5.0")
+	commitRepoFile(t, dir, "feature.txt", "feature\n", "feat: add changelog command")
+
+	output, err := runChangelogCommand(t, dir)
+	if err != nil {
+		t.Fatalf("runChangelogCommand failed: %v", err)
+	}
+
+	if !strings.Contains(output, "- Add changelog command") {
+		t.Fatalf("expected commit after nearest tag, got:\n%s", output)
+	}
+	if strings.Contains(output, "Release prep") {
+		t.Fatalf("expected commits before nearest tag to be excluded, got:\n%s", output)
+	}
+}
+
+func TestChangelogCommandHandlesMixedCommitStyles(t *testing.T) {
+	dir := initChangelogRepo(t)
+	runGitCommand(t, dir, "tag", "v0.1.0")
+	commitRepoFile(t, dir, "feature.txt", "feature\n", "feat(cli): add changelog command")
+	commitRepoFile(t, dir, "docs.md", "docs\n", "Document release workflow")
+	commitRepoFile(t, dir, "notes.txt", "notes\n", "Improve command help text")
+
+	output, err := runChangelogCommand(t, dir, "--version", "v0.2.0", "--date", "2026-04-23")
+	if err != nil {
+		t.Fatalf("runChangelogCommand failed: %v", err)
+	}
+
+	wantParts := []string{
+		"## [v0.2.0] - 2026-04-23",
+		"### Features\n- Add changelog command",
+		"### Documentation\n- Document release workflow",
+		"### Improvements\n- Improve command help text",
+	}
+	for _, part := range wantParts {
+		if !strings.Contains(output, part) {
+			t.Fatalf("expected output to contain %q, got:\n%s", part, output)
+		}
+	}
+}
+
+func TestChangelogCommandIgnoresAutosquashCommits(t *testing.T) {
+	dir := initChangelogRepo(t)
+	runGitCommand(t, dir, "tag", "v0.1.0")
+	commitRepoFile(t, dir, "feature.txt", "feature\n", "feat: add parser")
+	commitRepoFile(t, dir, "feature.txt", "feature updated\n", "fixup! feat: add parser")
+
+	output, err := runChangelogCommand(t, dir)
+	if err != nil {
+		t.Fatalf("runChangelogCommand failed: %v", err)
+	}
+
+	if strings.Count(output, "- Add parser\n") != 1 {
+		t.Fatalf("expected a single feature bullet, got:\n%s", output)
+	}
+}
+
+func TestChangelogCommandErrorsOnEmptyRange(t *testing.T) {
+	dir := initChangelogRepo(t)
+	runGitCommand(t, dir, "tag", "v0.1.0")
+
+	_, err := runChangelogCommand(t, dir)
+	if err == nil {
+		t.Fatal("expected error for empty range")
+	}
+	if !strings.Contains(err.Error(), "no commits found in range v0.1.0..HEAD") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestChangelogCommandRequiresFromWhenNoTagsExist(t *testing.T) {
+	dir := initChangelogRepo(t)
+	commitRepoFile(t, dir, "feature.txt", "feature\n", "feat: add changelog command")
+
+	_, err := runChangelogCommand(t, dir)
+	if err == nil {
+		t.Fatal("expected error when no tags exist")
+	}
+	if !strings.Contains(err.Error(), "could not determine default changelog range") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "use --from <ref>") {
+		t.Fatalf("expected helpful hint, got: %v", err)
+	}
+}
+
+func TestChangelogCommandRejectsDateWithoutVersion(t *testing.T) {
+	dir := initChangelogRepo(t)
+	runGitCommand(t, dir, "tag", "v0.1.0")
+	commitRepoFile(t, dir, "feature.txt", "feature\n", "feat: add changelog command")
+
+	_, err := runChangelogCommand(t, dir, "--date", "2026-04-23")
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "--date requires --version") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/docs/guides/releasing-new-version.md
+++ b/docs/guides/releasing-new-version.md
@@ -33,22 +33,21 @@ Check current version:
 git tag -l | sort -V | tail -1
 ```
 
-### 2. Update CHANGELOG.md
+### 2. Generate and Review the Changelog
 
-Add entry at the top of `CHANGELOG.md`:
+Generate markdown from commits since the nearest reachable semver tag:
 
-```markdown
-## [vX.Y.Z] - YYYY-MM-DD
-
-### Features
-- New feature description
-
-### Bug Fixes
-- Fix description
-
-### Documentation
-- Doc change description
+```bash
+td changelog --version vX.Y.Z --date YYYY-MM-DD > /tmp/td-changelog.md
 ```
+
+If you need a custom range, pass explicit refs:
+
+```bash
+td changelog --from vX.Y.Z --to HEAD
+```
+
+Review `/tmp/td-changelog.md`, then prepend the generated entry to `CHANGELOG.md`.
 
 Commit the changelog:
 ```bash
@@ -134,8 +133,9 @@ Replace `X.Y.Z` with actual version:
 git status
 go test ./...
 
-# Update changelog
-# (Edit CHANGELOG.md, add entry at top)
+# Generate and review changelog
+td changelog --version vX.Y.Z --date YYYY-MM-DD > /tmp/td-changelog.md
+# (Prepend reviewed output from /tmp/td-changelog.md to CHANGELOG.md)
 git add CHANGELOG.md
 git commit -m "docs: Update changelog for vX.Y.Z"
 
@@ -154,7 +154,8 @@ brew upgrade td && td version
 
 - [ ] Tests pass (`go test ./...`)
 - [ ] Working tree clean
-- [ ] CHANGELOG.md updated with new version entry
+- [ ] `td changelog --version vX.Y.Z --date YYYY-MM-DD` reviewed
+- [ ] CHANGELOG.md updated with generated release entry
 - [ ] Changelog committed to git
 - [ ] Version number follows semver
 - [ ] Commits pushed to main

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -124,12 +124,12 @@ func classifyCommit(commit gitutil.Commit) (section, string, bool) {
 
 	lower := strings.ToLower(normalized)
 	switch {
-	case isDocumentationSummary(lower):
-		return sectionDocumentation, normalized, true
 	case isFeatureSummary(lower):
 		return sectionFeatures, normalized, true
 	case isBugFixSummary(lower):
 		return sectionBugFixes, normalized, true
+	case isDocumentationSummary(lower):
+		return sectionDocumentation, normalized, true
 	default:
 		return sectionImprovements, normalized, true
 	}

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -1,0 +1,217 @@
+package changelog
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+
+	gitutil "github.com/marcus/td/internal/git"
+)
+
+// ErrNoRelevantCommits is returned when a commit range contains no changelog-worthy commits.
+var ErrNoRelevantCommits = errors.New("no relevant commits")
+
+// Options configures markdown rendering.
+type Options struct {
+	Version string
+	Date    string
+}
+
+type section string
+
+const (
+	sectionFeatures      section = "Features"
+	sectionBugFixes      section = "Bug Fixes"
+	sectionDocumentation section = "Documentation"
+	sectionImprovements  section = "Improvements"
+)
+
+var (
+	conventionalPrefixPattern = regexp.MustCompile(`^(?i)(build|chore|ci|docs?|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?(!)?:\s*`)
+	fixupPrefixPattern        = regexp.MustCompile(`^(?i)(fixup!|squash!)\s*`)
+	pullRequestSuffixPattern  = regexp.MustCompile(`\s+\(#\d+\)$`)
+	spacePattern              = regexp.MustCompile(`\s+`)
+	orderedSections           = []section{
+		sectionFeatures,
+		sectionBugFixes,
+		sectionDocumentation,
+		sectionImprovements,
+	}
+)
+
+// RenderMarkdown converts commits into grouped changelog markdown.
+func RenderMarkdown(commits []gitutil.Commit, opts Options) (string, error) {
+	grouped := make(map[section][]string)
+	total := 0
+
+	for _, commit := range commits {
+		section, summary, ok := classifyCommit(commit)
+		if !ok {
+			continue
+		}
+		grouped[section] = append(grouped[section], summary)
+		total++
+	}
+
+	if total == 0 {
+		return "", ErrNoRelevantCommits
+	}
+
+	var b strings.Builder
+	b.WriteString(renderHeading(opts))
+	b.WriteString("\n\n")
+
+	wroteSection := false
+	for _, current := range orderedSections {
+		items := grouped[current]
+		if len(items) == 0 {
+			continue
+		}
+		if wroteSection {
+			b.WriteString("\n")
+		}
+		b.WriteString("### ")
+		b.WriteString(string(current))
+		b.WriteString("\n")
+		for _, item := range items {
+			b.WriteString("- ")
+			b.WriteString(item)
+			b.WriteString("\n")
+		}
+		wroteSection = true
+	}
+
+	return strings.TrimRight(b.String(), "\n") + "\n", nil
+}
+
+func renderHeading(opts Options) string {
+	version := strings.TrimSpace(opts.Version)
+	date := strings.TrimSpace(opts.Date)
+
+	if version == "" {
+		return "## Unreleased"
+	}
+	if date == "" {
+		return fmt.Sprintf("## [%s]", version)
+	}
+	return fmt.Sprintf("## [%s] - %s", version, date)
+}
+
+func classifyCommit(commit gitutil.Commit) (section, string, bool) {
+	if isAutosquashCommit(commit.Subject) {
+		return "", "", false
+	}
+
+	normalized := normalizeSubject(commit.Subject)
+	if normalized == "" {
+		return "", "", false
+	}
+
+	if commitType := conventionalType(commit.Subject); commitType != "" {
+		switch commitType {
+		case "feat":
+			return sectionFeatures, normalized, true
+		case "fix":
+			return sectionBugFixes, normalized, true
+		case "doc", "docs":
+			return sectionDocumentation, normalized, true
+		default:
+			return sectionImprovements, normalized, true
+		}
+	}
+
+	lower := strings.ToLower(normalized)
+	switch {
+	case isDocumentationSummary(lower):
+		return sectionDocumentation, normalized, true
+	case isFeatureSummary(lower):
+		return sectionFeatures, normalized, true
+	case isBugFixSummary(lower):
+		return sectionBugFixes, normalized, true
+	default:
+		return sectionImprovements, normalized, true
+	}
+}
+
+func conventionalType(subject string) string {
+	subject = strings.TrimSpace(subject)
+	matches := conventionalPrefixPattern.FindStringSubmatch(subject)
+	if len(matches) < 2 {
+		return ""
+	}
+	return strings.ToLower(matches[1])
+}
+
+func normalizeSubject(subject string) string {
+	normalized := strings.TrimSpace(subject)
+	if normalized == "" || isMergeNoise(normalized) {
+		return ""
+	}
+
+	normalized = fixupPrefixPattern.ReplaceAllString(normalized, "")
+	normalized = conventionalPrefixPattern.ReplaceAllString(normalized, "")
+	normalized = pullRequestSuffixPattern.ReplaceAllString(normalized, "")
+	normalized = strings.TrimSuffix(strings.TrimSpace(normalized), ".")
+	normalized = spacePattern.ReplaceAllString(normalized, " ")
+	normalized = strings.TrimSpace(normalized)
+	if normalized == "" {
+		return ""
+	}
+
+	return upperFirst(normalized)
+}
+
+func isAutosquashCommit(subject string) bool {
+	return fixupPrefixPattern.MatchString(strings.TrimSpace(subject))
+}
+
+func isMergeNoise(subject string) bool {
+	lower := strings.ToLower(strings.TrimSpace(subject))
+	return strings.HasPrefix(lower, "merge ")
+}
+
+func isDocumentationSummary(subject string) bool {
+	docPrefixes := []string{"document ", "docs ", "readme", "guide ", "comment ", "commentary "}
+	docContains := []string{"documentation", "readme", "changelog", "command reference", "release guide", "docs/"}
+	return hasPrefix(subject, docPrefixes...) || containsAny(subject, docContains...)
+}
+
+func isFeatureSummary(subject string) bool {
+	featurePrefixes := []string{"add ", "allow ", "create ", "enable ", "generate ", "implement ", "introduce ", "support "}
+	return hasPrefix(subject, featurePrefixes...)
+}
+
+func isBugFixSummary(subject string) bool {
+	bugPrefixes := []string{"fix ", "avoid ", "correct ", "handle ", "prevent ", "resolve "}
+	bugContains := []string{" bug", "panic", "crash", "regression"}
+	return hasPrefix(subject, bugPrefixes...) || containsAny(subject, bugContains...)
+}
+
+func hasPrefix(subject string, prefixes ...string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(subject, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAny(subject string, parts ...string) bool {
+	for _, part := range parts {
+		if strings.Contains(subject, part) {
+			return true
+		}
+	}
+	return false
+}
+
+func upperFirst(subject string) string {
+	runes := []rune(subject)
+	if len(runes) == 0 {
+		return subject
+	}
+	runes[0] = unicode.ToUpper(runes[0])
+	return string(runes)
+}

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -1,0 +1,91 @@
+package changelog
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	gitutil "github.com/marcus/td/internal/git"
+)
+
+func TestRenderMarkdownGroupsConventionalAndLooseSubjects(t *testing.T) {
+	commits := []gitutil.Commit{
+		{Subject: "feat(cli): add changelog command"},
+		{Subject: "fix: handle empty ranges"},
+		{Subject: "docs: update release guide"},
+		{Subject: "Improve command help text"},
+		{Subject: "Merge pull request #42 from feature/changelog"},
+	}
+
+	got, err := RenderMarkdown(commits, Options{})
+	if err != nil {
+		t.Fatalf("RenderMarkdown failed: %v", err)
+	}
+
+	wantParts := []string{
+		"## Unreleased",
+		"### Features\n- Add changelog command",
+		"### Bug Fixes\n- Handle empty ranges",
+		"### Documentation\n- Update release guide",
+		"### Improvements\n- Improve command help text",
+	}
+	for _, part := range wantParts {
+		if !strings.Contains(got, part) {
+			t.Fatalf("expected output to contain %q, got:\n%s", part, got)
+		}
+	}
+	if strings.Contains(got, "Merge pull request") {
+		t.Fatalf("expected merge commit to be ignored, got:\n%s", got)
+	}
+}
+
+func TestRenderMarkdownWithVersionAndDate(t *testing.T) {
+	commits := []gitutil.Commit{
+		{
+			Subject:    "feat: add changelog command",
+			CommitDate: time.Date(2026, 4, 23, 10, 0, 0, 0, time.UTC),
+		},
+	}
+
+	got, err := RenderMarkdown(commits, Options{
+		Version: "v0.9.0",
+		Date:    "2026-04-23",
+	})
+	if err != nil {
+		t.Fatalf("RenderMarkdown failed: %v", err)
+	}
+
+	if !strings.HasPrefix(got, "## [v0.9.0] - 2026-04-23\n\n") {
+		t.Fatalf("unexpected heading:\n%s", got)
+	}
+}
+
+func TestRenderMarkdownRequiresRelevantCommits(t *testing.T) {
+	_, err := RenderMarkdown([]gitutil.Commit{
+		{Subject: "Merge branch 'main' into feature/changelog"},
+	}, Options{})
+	if !errors.Is(err, ErrNoRelevantCommits) {
+		t.Fatalf("expected ErrNoRelevantCommits, got %v", err)
+	}
+}
+
+func TestRenderMarkdownIgnoresAutosquashCommits(t *testing.T) {
+	commits := []gitutil.Commit{
+		{Subject: "feat: add parser"},
+		{Subject: "fixup! feat: add parser"},
+		{Subject: "squash! docs: update parser guide"},
+	}
+
+	got, err := RenderMarkdown(commits, Options{})
+	if err != nil {
+		t.Fatalf("RenderMarkdown failed: %v", err)
+	}
+
+	if strings.Count(got, "- Add parser\n") != 1 {
+		t.Fatalf("expected a single feature entry, got:\n%s", got)
+	}
+	if strings.Contains(got, "Update parser guide") {
+		t.Fatalf("expected squash commit to be ignored, got:\n%s", got)
+	}
+}

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -89,3 +89,27 @@ func TestRenderMarkdownIgnoresAutosquashCommits(t *testing.T) {
 		t.Fatalf("expected squash commit to be ignored, got:\n%s", got)
 	}
 }
+
+func TestRenderMarkdownPrefersFeatureAndBugHeuristicsOverDocKeywords(t *testing.T) {
+	commits := []gitutil.Commit{
+		{Subject: "add README examples for changelog command"},
+		{Subject: "fix changelog heading in release output"},
+		{Subject: "document README release workflow"},
+	}
+
+	got, err := RenderMarkdown(commits, Options{})
+	if err != nil {
+		t.Fatalf("RenderMarkdown failed: %v", err)
+	}
+
+	wantParts := []string{
+		"### Features\n- Add README examples for changelog command",
+		"### Bug Fixes\n- Fix changelog heading in release output",
+		"### Documentation\n- Document README release workflow",
+	}
+	for _, part := range wantParts {
+		if !strings.Contains(got, part) {
+			t.Fatalf("expected output to contain %q, got:\n%s", part, got)
+		}
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -6,8 +6,10 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // State represents the current git state
@@ -19,6 +21,16 @@ type State struct {
 	Untracked  int
 	DirtyFiles int
 }
+
+// Commit represents a git commit returned from a ref range query.
+type Commit struct {
+	SHA        string
+	Subject    string
+	Body       string
+	CommitDate time.Time
+}
+
+var semverTagPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$`)
 
 // GetState returns the current git state
 func GetState() (*State, error) {
@@ -192,8 +204,85 @@ func GetRootDir() (string, error) {
 	return strings.TrimSpace(output), nil
 }
 
+// ResolveRefInDir resolves a commit-ish within the given repository directory.
+func ResolveRefInDir(dir, ref string) (string, error) {
+	output, err := runGitInDir(dir, "rev-parse", "--verify", ref+"^{commit}")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(output), nil
+}
+
+// GetLatestReleaseTagInDir returns the nearest semver tag reachable from HEAD.
+func GetLatestReleaseTagInDir(dir string) (string, error) {
+	output, err := runGitInDir(
+		dir,
+		"describe",
+		"--tags",
+		"--abbrev=0",
+		"--match",
+		"v[0-9]*.[0-9]*.[0-9]*",
+		"--match",
+		"[0-9]*.[0-9]*.[0-9]*",
+		"HEAD",
+	)
+	if err != nil {
+		return "", fmt.Errorf("no semver tags found")
+	}
+
+	tag := strings.TrimSpace(output)
+	if tag == "" || !semverTagPattern.MatchString(tag) {
+		return "", fmt.Errorf("no semver tags found")
+	}
+
+	return tag, nil
+}
+
+// ListCommitsInRangeInDir returns commits between from..to in oldest-first order.
+func ListCommitsInRangeInDir(dir, from, to string) ([]Commit, error) {
+	rangeSpec := strings.TrimSpace(from) + ".." + strings.TrimSpace(to)
+	output, err := runGitInDir(dir, "log", "--reverse", "--format=%H%x1f%s%x1f%b%x1f%cI%x1e", rangeSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	var commits []Commit
+	for _, rawEntry := range strings.Split(output, "\x1e") {
+		rawEntry = strings.TrimSpace(rawEntry)
+		if rawEntry == "" {
+			continue
+		}
+
+		fields := strings.SplitN(rawEntry, "\x1f", 4)
+		if len(fields) != 4 {
+			return nil, fmt.Errorf("unexpected git log format for range %s", rangeSpec)
+		}
+
+		commitDate, err := time.Parse(time.RFC3339, strings.TrimSpace(fields[3]))
+		if err != nil {
+			return nil, fmt.Errorf("parse commit date: %w", err)
+		}
+
+		commits = append(commits, Commit{
+			SHA:        strings.TrimSpace(fields[0]),
+			Subject:    strings.TrimSpace(fields[1]),
+			Body:       strings.TrimSpace(fields[2]),
+			CommitDate: commitDate,
+		})
+	}
+
+	return commits, nil
+}
+
 func runGit(args ...string) (string, error) {
+	return runGitInDir("", args...)
+}
+
+func runGitInDir(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -43,6 +44,31 @@ func runCmd(dir string, name string, args ...string) error {
 	cmd := exec.Command(name, args...)
 	cmd.Dir = dir
 	return cmd.Run()
+}
+
+func runCmdOutput(t *testing.T, dir string, name string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v failed: %v (%s)", name, args, err, strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func commitFile(t *testing.T, dir, fileName, content, message string) string {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, fileName), []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	if err := runCmd(dir, "git", "add", fileName); err != nil {
+		t.Fatalf("Failed to git add: %v", err)
+	}
+	if err := runCmd(dir, "git", "commit", "-m", message); err != nil {
+		t.Fatalf("Failed to commit: %v", err)
+	}
+	return runCmdOutput(t, dir, "git", "rev-parse", "HEAD")
 }
 
 // TestParseStatOutputBasic tests parsing git diff --stat output
@@ -467,5 +493,121 @@ func TestStateBranchName(t *testing.T) {
 	// The branch should be either 'main', 'master', or some default
 	if state.Branch != "main" && state.Branch != "master" && state.Branch != "HEAD" {
 		t.Logf("Branch name is %q (expected main/master/HEAD)", state.Branch)
+	}
+}
+
+func TestResolveRefInDir(t *testing.T) {
+	dir := initTestRepo(t)
+
+	head := runCmdOutput(t, dir, "git", "rev-parse", "HEAD")
+	got, err := ResolveRefInDir(dir, "HEAD")
+	if err != nil {
+		t.Fatalf("ResolveRefInDir failed: %v", err)
+	}
+
+	if got != head {
+		t.Fatalf("resolved ref = %q, want %q", got, head)
+	}
+}
+
+func TestGetLatestReleaseTagInDir(t *testing.T) {
+	dir := initTestRepo(t)
+
+	if err := runCmd(dir, "git", "tag", "preview-build"); err != nil {
+		t.Fatalf("Failed to create non-semver tag: %v", err)
+	}
+	if err := runCmd(dir, "git", "tag", "v0.1.0"); err != nil {
+		t.Fatalf("Failed to create v0.1.0 tag: %v", err)
+	}
+
+	commitFile(t, dir, "feature.txt", "feature\n", "feat: add feature")
+
+	if err := runCmd(dir, "git", "tag", "v0.2.0"); err != nil {
+		t.Fatalf("Failed to create v0.2.0 tag: %v", err)
+	}
+
+	tag, err := GetLatestReleaseTagInDir(dir)
+	if err != nil {
+		t.Fatalf("GetLatestReleaseTagInDir failed: %v", err)
+	}
+
+	if tag != "v0.2.0" {
+		t.Fatalf("latest tag = %q, want %q", tag, "v0.2.0")
+	}
+}
+
+func TestGetLatestReleaseTagInDirPrefersNearestAncestorTag(t *testing.T) {
+	dir := initTestRepo(t)
+
+	if err := runCmd(dir, "git", "tag", "v2.0.0"); err != nil {
+		t.Fatalf("Failed to create v2.0.0 tag: %v", err)
+	}
+
+	commitFile(t, dir, "mid.txt", "mid\n", "feat: intermediate release prep")
+
+	if err := runCmd(dir, "git", "tag", "v1.5.0"); err != nil {
+		t.Fatalf("Failed to create v1.5.0 tag: %v", err)
+	}
+
+	commitFile(t, dir, "after.txt", "after\n", "feat: final release work")
+
+	tag, err := GetLatestReleaseTagInDir(dir)
+	if err != nil {
+		t.Fatalf("GetLatestReleaseTagInDir failed: %v", err)
+	}
+
+	if tag != "v1.5.0" {
+		t.Fatalf("latest tag = %q, want %q", tag, "v1.5.0")
+	}
+}
+
+func TestGetLatestReleaseTagInDirRequiresSemverTag(t *testing.T) {
+	dir := initTestRepo(t)
+
+	if err := runCmd(dir, "git", "tag", "preview-build"); err != nil {
+		t.Fatalf("Failed to create non-semver tag: %v", err)
+	}
+
+	_, err := GetLatestReleaseTagInDir(dir)
+	if err == nil {
+		t.Fatal("expected error when no semver tags exist")
+	}
+	if !strings.Contains(err.Error(), "no semver tags found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestListCommitsInRangeInDir(t *testing.T) {
+	dir := initTestRepo(t)
+
+	if err := runCmd(dir, "git", "tag", "v0.1.0"); err != nil {
+		t.Fatalf("Failed to create tag: %v", err)
+	}
+
+	firstSHA := commitFile(t, dir, "feature.txt", "feature\n", "feat(cli): add changelog command")
+	secondSHA := commitFile(t, dir, "docs.md", "docs\n", "docs: update release guide")
+
+	commits, err := ListCommitsInRangeInDir(dir, "v0.1.0", "HEAD")
+	if err != nil {
+		t.Fatalf("ListCommitsInRangeInDir failed: %v", err)
+	}
+
+	if len(commits) != 2 {
+		t.Fatalf("expected 2 commits, got %d", len(commits))
+	}
+	if commits[0].SHA != firstSHA {
+		t.Fatalf("first commit sha = %q, want %q", commits[0].SHA, firstSHA)
+	}
+	if commits[0].Subject != "feat(cli): add changelog command" {
+		t.Fatalf("first commit subject = %q", commits[0].Subject)
+	}
+	if commits[1].SHA != secondSHA {
+		t.Fatalf("second commit sha = %q, want %q", commits[1].SHA, secondSHA)
+	}
+	if commits[1].Subject != "docs: update release guide" {
+		t.Fatalf("second commit subject = %q", commits[1].Subject)
+	}
+	if commits[0].CommitDate.IsZero() || commits[1].CommitDate.IsZero() {
+		t.Fatal("expected commit dates to be populated")
 	}
 }

--- a/website/docs/command-reference.md
+++ b/website/docs/command-reference.md
@@ -138,6 +138,7 @@ cat docs/acceptance.md | td update td-a1b2 --append --acceptance-file -
 
 | Command | Description |
 |---------|-------------|
+| `td changelog [flags]` | Generate changelog markdown from git commits. Flags: `--from`, `--to`, `--version`, `--date` |
 | `td init` | Initialize project |
 | `td monitor` | Live TUI dashboard |
 | `td undo` | Undo last action |
@@ -145,3 +146,5 @@ cat docs/acceptance.md | td update td-a1b2 --append --acceptance-file -
 | `td export` | Export database |
 | `td import` | Import issues |
 | `td stats [subcommand]` | Usage statistics |
+
+`td changelog` defaults to commits from the nearest reachable semver tag through `HEAD` and prints markdown to stdout. Use `--version vX.Y.Z --date YYYY-MM-DD` when generating a release entry for `CHANGELOG.md`, or pass `--from` / `--to` for an explicit ref range.


### PR DESCRIPTION
## Summary
- cherry-pick the current `td changelog` implementation onto a fresh branch from `codex/lint-fix`
- classify loose commit subjects as features/bug fixes before falling back to documentation keywords
- add regression coverage in both `internal/changelog` and `cmd/changelog_test.go` for README/changelog phrasing

## Testing
- go test ./internal/changelog ./internal/git ./cmd
- go test ./...


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: changelog-synth:/Users/marcus/code/td
task-type: changelog-synth
task-title: Changelog Synthesizer
provider: codex
score: 0.7
cost-tier: Low (10-50k)
branch: codex/lint-fix
iterations: 3
duration: 39m15s
run-started: 2026-04-23T02:58:47-07:00
nightshift:metadata -->
