### PR TITLE
chore: add commit message normalizer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,5 +74,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/td.rb
           git diff --cached --quiet && echo "No changes" && exit 0
-          git commit -m "td: bump to ${{ steps.version.outputs.version }}"
+          git commit -m "chore: update td to ${{ steps.version.outputs.version }}"
           git push

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help:
 	@printf "%s\n" \
 		"Targets:" \
 		"  make fmt                       # gofmt -w ." \
-		"  make install-hooks             # install git pre-commit hook" \
+		"  make install-hooks             # install git hooks" \
 		"  make test                      # go test ./..." \
 		"  make install                   # build and install with version from git" \
 		"  make tag VERSION=vX.Y.Z        # create annotated git tag (requires clean tree)" \
@@ -52,6 +52,10 @@ release: tag
 	git push origin "$(VERSION)"
 
 install-hooks:
-	@echo "Installing git pre-commit hook..."
-	@ln -sf ../../scripts/pre-commit.sh .git/hooks/pre-commit
-	@echo "Done. Hook installed at .git/hooks/pre-commit"
+	@echo "Installing git hooks..."
+	@hooks_dir=$$(git rev-parse --git-common-dir)/hooks; \
+	repo_root=$$(git rev-parse --show-toplevel); \
+	mkdir -p "$$hooks_dir"; \
+	ln -sf "$$repo_root/scripts/pre-commit.sh" "$$hooks_dir/pre-commit"; \
+	ln -sf "$$repo_root/scripts/commit-msg.sh" "$$hooks_dir/commit-msg"; \
+	echo "Done. Hooks installed at $$hooks_dir/pre-commit and $$hooks_dir/commit-msg"

--- a/README.md
+++ b/README.md
@@ -189,9 +189,20 @@ make install-dev
 # Format code
 make fmt
 
-# Install git pre-commit hook (gofmt, go vet, go build on staged files)
+# Install git hooks
 make install-hooks
 ```
+
+`make install-hooks` installs:
+
+- `pre-commit`: runs gofmt, go vet, and go build against staged Go changes.
+- `commit-msg`: normalizes the first line of regular commits to
+  Conventional Commit format while preserving the body and trailers.
+
+Commit subjects should use `type: subject` or `type(scope): subject`.
+Allowed types are `feat`, `fix`, `docs`, `test`, `refactor`, `chore`,
+`ci`, `build`, `perf`, `style`, and `td`. Merge, revert, fixup, and squash
+messages are passed through unchanged.
 
 ## Tests & Quality Checks
 
@@ -208,6 +219,9 @@ make test
 make fmt
 
 # No linter configured yet — clean gofmt is current quality bar
+
+# Verify the commit-msg hook
+scripts/test-commit-msg-hook.sh
 ```
 
 ## Release

--- a/docs/guides/releasing-new-version.md
+++ b/docs/guides/releasing-new-version.md
@@ -53,7 +53,7 @@ Add entry at the top of `CHANGELOG.md`:
 Commit the changelog:
 ```bash
 git add CHANGELOG.md
-git commit -m "docs: Update changelog for vX.Y.Z"
+git commit -m "docs: update changelog for vX.Y.Z"
 ```
 
 ### 3. Verify Tests Pass
@@ -137,7 +137,7 @@ go test ./...
 # Update changelog
 # (Edit CHANGELOG.md, add entry at top)
 git add CHANGELOG.md
-git commit -m "docs: Update changelog for vX.Y.Z"
+git commit -m "docs: update changelog for vX.Y.Z"
 
 # Push commits, then tag (tag push triggers automated release)
 git push origin main

--- a/scripts/commit-msg.sh
+++ b/scripts/commit-msg.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# commit-msg hook for td
+# Install: make install-hooks
+set -euo pipefail
+
+allowed_types='feat|fix|docs|test|refactor|chore|ci|build|perf|style|td'
+passthrough='^(Merge( |$)|Revert( |$)|fixup!|squash!)'
+
+usage() {
+  echo "usage: commit-msg <path-to-commit-message-file>" >&2
+}
+
+invalid() {
+  cat >&2 <<EOF
+Invalid commit subject: $1
+
+Use Conventional Commit format:
+  type: subject
+  type(scope): subject
+
+Allowed types: feat, fix, docs, test, refactor, chore, ci, build, perf, style, td
+EOF
+  exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 1
+fi
+
+msg_file=$1
+if [[ ! -f "$msg_file" ]]; then
+  echo "commit message file not found: $msg_file" >&2
+  exit 1
+fi
+
+IFS= read -r first_line < "$msg_file" || first_line=""
+
+if [[ "$first_line" =~ $passthrough ]]; then
+  exit 0
+fi
+
+subject=$(printf '%s' "$first_line" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/[[:space:]]+/ /g')
+
+shopt -s nocasematch
+if [[ "$subject" =~ ^($allowed_types)(\([A-Za-z0-9._/-]+\))?(!)?[[:space:]]*:[[:space:]]*(.+)$ ]]; then
+  type=$(printf '%s' "${BASH_REMATCH[1]}" | tr '[:upper:]' '[:lower:]')
+  scope=${BASH_REMATCH[2]}
+  bang=${BASH_REMATCH[3]}
+  summary=$(printf '%s' "${BASH_REMATCH[4]}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/[[:space:]]+/ /g')
+  [[ -n "$summary" ]] || invalid "$first_line"
+  normalized="${type}${scope}${bang}: ${summary}"
+else
+  invalid "$first_line"
+fi
+shopt -u nocasematch
+
+if [[ "$normalized" == "$first_line" ]]; then
+  exit 0
+fi
+
+tmp=$(mktemp "${msg_file}.XXXXXX")
+trap 'rm -f "$tmp"' EXIT
+
+printf '%s\n' "$normalized" > "$tmp"
+tail -n +2 "$msg_file" >> "$tmp" || true
+mv "$tmp" "$msg_file"
+trap - EXIT

--- a/scripts/test-commit-msg-hook.sh
+++ b/scripts/test-commit-msg-hook.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+hook="$root/scripts/commit-msg.sh"
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file() {
+  local got=$1
+  local want=$2
+  if ! cmp -s "$got" "$want"; then
+    diff -u "$want" "$got" >&2 || true
+    fail "file content differed"
+  fi
+}
+
+msg="$tmpdir/normalize-msg"
+want="$tmpdir/normalize-want"
+cat > "$msg" <<'EOF'
+  Feat  :   Add   commit    hook
+
+Body  keeps   its spacing.
+
+Nightshift-Task: commit-normalize
+Nightshift-Ref: https://github.com/marcus/nightshift
+EOF
+cat > "$want" <<'EOF'
+feat: Add commit hook
+
+Body  keeps   its spacing.
+
+Nightshift-Task: commit-normalize
+Nightshift-Ref: https://github.com/marcus/nightshift
+EOF
+"$hook" "$msg"
+assert_file "$msg" "$want"
+
+msg="$tmpdir/scope-msg"
+printf 'FIX(api)!:  preserve    scope\n' > "$msg"
+printf 'fix(api)!: preserve scope\n' > "$want"
+"$hook" "$msg"
+assert_file "$msg" "$want"
+
+for subject in \
+  "Merge branch 'main'" \
+  'Revert "feat: add thing"' \
+  'fixup! feat: add thing' \
+  'squash! feat: add thing'
+do
+  msg="$tmpdir/pass-through-msg"
+  printf '%s\n\nunchanged body\n' "$subject" > "$msg"
+  cp "$msg" "$want"
+  "$hook" "$msg"
+  assert_file "$msg" "$want"
+done
+
+msg="$tmpdir/invalid-msg"
+printf 'Update docs\n\nNightshift-Task: commit-normalize\n' > "$msg"
+if "$hook" "$msg" 2> "$tmpdir/invalid-err"; then
+  fail "invalid subject unexpectedly passed"
+fi
+grep -q "Invalid commit subject" "$tmpdir/invalid-err" || fail "missing invalid-subject error"
+grep -q "Nightshift-Task: commit-normalize" "$msg" || fail "invalid message trailers were rewritten"
+
+echo "commit-msg hook tests passed"


### PR DESCRIPTION
## Summary
- add a repo-owned commit-msg hook that normalizes Conventional Commit subjects and preserves bodies/trailers
- install the commit-msg hook alongside pre-commit via make install-hooks
- document the commit format and update release automation/examples

## Verification
- scripts/test-commit-msg-hook.sh
- make -n install-hooks
- go test ./...


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: commit-normalize:/Users/marcus/code/td
task-type: commit-normalize
task-title: Commit Message Normalizer
provider: codex
score: 0.3
cost-tier: Low (10-50k)
branch: codex/lint-fix
iterations: 1
duration: 16m32s
run-started: 2026-04-25T02:19:28-07:00
nightshift:metadata -->
