### PR TITLE
fix: build internal/config on Windows

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,13 +6,15 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"syscall"
 
 	"github.com/marcus/td/internal/models"
 )
 
 const configFile = ".todos/config.json"
 const lockFile = ".todos/config.json.lock"
+
+// withConfigLock serializes access to config.json using an OS file lock.
+// Implemented per-platform in lock_unix.go (flock) and lock_windows.go (LockFileEx).
 
 // Title validation defaults
 const (
@@ -73,28 +75,6 @@ func Save(baseDir string, cfg *models.Config) error {
 	}
 
 	return os.Rename(tmpName, configPath)
-}
-
-// withConfigLock serializes access to config.json using flock
-func withConfigLock(baseDir string, fn func() error) error {
-	lockPath := filepath.Join(baseDir, lockFile)
-
-	if err := os.MkdirAll(filepath.Dir(lockPath), 0755); err != nil {
-		return err
-	}
-
-	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
-		return err
-	}
-	defer func() { _ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN) }()
-
-	return fn()
 }
 
 // SetFocus sets the focused issue ID

--- a/internal/config/lock_unix.go
+++ b/internal/config/lock_unix.go
@@ -1,0 +1,31 @@
+//go:build unix
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// withConfigLock serializes access to config.json using flock.
+func withConfigLock(baseDir string, fn func() error) error {
+	lockPath := filepath.Join(baseDir, lockFile)
+
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0755); err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		return err
+	}
+	defer func() { _ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN) }()
+
+	return fn()
+}

--- a/internal/config/lock_windows.go
+++ b/internal/config/lock_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+// withConfigLock serializes access to config.json using LockFileEx.
+func withConfigLock(baseDir string, fn func() error) error {
+	lockPath := filepath.Join(baseDir, lockFile)
+
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0755); err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// LockFileEx with LOCKFILE_EXCLUSIVE_LOCK (blocking) locks the first byte
+	// of the file, which is sufficient for whole-file mutual exclusion since
+	// every contender uses the same offset/length.
+	ol := new(windows.Overlapped)
+	if err := windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0, // reserved
+		1, // lock 1 byte
+		0, // high bits of length
+		ol,
+	); err != nil {
+		return err
+	}
+	defer func() {
+		ul := new(windows.Overlapped)
+		_ = windows.UnlockFileEx(windows.Handle(f.Fd()), 0, 1, 0, ul)
+	}()
+
+	return fn()
+}


### PR DESCRIPTION
## Summary

- `internal/config/config.go` imports `syscall` and calls `syscall.Flock` /
  `syscall.LOCK_EX` / `syscall.LOCK_UN` directly, none of which exist in the
  Windows `syscall` package. `go install github.com/marcus/td@latest` fails on
  Windows with `undefined: syscall.Flock` before any other build error.
- Split `withConfigLock` into platform-specific files, mirroring the existing
  pattern in `internal/db/lock_{unix,windows}.go` and
  `internal/serve/portfile_{unix,windows}.go`:
  - `lock_unix.go` — flock-based, semantically unchanged from the previous
    inline implementation.
  - `lock_windows.go` — `LockFileEx` with `LOCKFILE_EXCLUSIVE_LOCK` (blocking),
    matching the Unix `LOCK_EX` semantics.

No behavior change on Unix. `go build ./...` now succeeds on `windows/arm64`
(also verified via `GOOS=linux go build ./...` cross-compile).

## Test plan

- [x] `go build ./...` on `windows/arm64` — clean.
- [x] `GOOS=linux go build ./...` — clean.
- [x] `go test ./internal/config/...` on Windows — all locking-relevant suites
      pass (`TestFocus`, `TestActiveWorkSession`, `TestFeatureFlags`,
      `TestPaneHeights`, `TestFilterState`, `TestEdgeCases`, including the
      ten-goroutine `TestEdgeCases/concurrent_operations` that exercises the
      lock under contention).
- [x] End-to-end smoke: `td init` → `td create ...` → `td list` in a scratch
      dir on Windows; lock file written under `.todos/config.json.lock`, no
      errors.
- [ ] CI on Linux/macOS — please confirm Unix paths still pass; no functional
      change expected since `lock_unix.go` is byte-for-byte equivalent to the
      previous inline code modulo the build tag.

### Pre-existing failures (not introduced by this PR)

`TestPermissionErrors` in `internal/config/config_test.go` fails on Windows
because it uses POSIX `os.Chmod(..., 0000)` / `0555` to make files/dirs
unreadable/unwritable, which don't translate to Windows ACLs. Separate issue;
happy to file or fix as a follow-up if useful.